### PR TITLE
[FEATURE] Random markings

### DIFF
--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.BasicInfo.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.BasicInfo.cs
@@ -38,17 +38,12 @@ public sealed partial class HumanoidProfileEditor
         {
             return;
         }
-        HumanoidCharacterAppearance.Random(Profile.Species, Profile.Sex);
-        Profile = new HumanoidCharacterProfile()
-        {
-            Name = Profile.Name,
-            Sex = Profile.Sex,
-            Age = Profile.Age,
-            Gender = Profile.Gender,
-            Species = Profile.Species,
-            Appearance = HumanoidCharacterAppearance.Random(Profile.Species, Profile.Sex),
-        };
+
+        var appearance = HumanoidCharacterAppearance.Random(Profile.Species, Profile.Sex);
+
+        Profile = Profile.WithCharacterAppearance(appearance);
         SetProfile(Profile, CharacterSlot);
+        SetDirty();
     }
 
     private void RandomizeName()

--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.BasicInfo.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.BasicInfo.cs
@@ -29,6 +29,7 @@ public sealed partial class HumanoidProfileEditor
         SetDirty();
     }
 
+    // MACRO ADD
     /// <summary>
     ///     Randomizes only the appearance of the character, without touching species, name, etc.
     /// </summary>

--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.BasicInfo.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.BasicInfo.cs
@@ -1,5 +1,6 @@
 
 using Content.Shared.Preferences;
+using Content.Shared.Humanoid; // MACRO
 
 namespace Content.Client.Lobby.UI;
 
@@ -26,6 +27,28 @@ public sealed partial class HumanoidProfileEditor
         Profile = HumanoidCharacterProfile.Random();
         SetProfile(Profile, CharacterSlot);
         SetDirty();
+    }
+
+    /// <summary>
+    ///     Randomizes only the appearance of the character, without touching species, name, etc.
+    /// </summary>
+    private void RandomizeAppearance()
+    {
+        if (Profile == null)
+        {
+            return;
+        }
+        HumanoidCharacterAppearance.Random(Profile.Species, Profile.Sex);
+        Profile = new HumanoidCharacterProfile()
+        {
+            Name = Profile.Name,
+            Sex = Profile.Sex,
+            Age = Profile.Age,
+            Gender = Profile.Gender,
+            Species = Profile.Species,
+            Appearance = HumanoidCharacterAppearance.Random(Profile.Species, Profile.Sex),
+        };
+        SetProfile(Profile, CharacterSlot);
     }
 
     private void RandomizeName()

--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml
@@ -20,9 +20,17 @@
                                         <LineEdit Name="NameEdit" MinSize="270 0" VerticalAlignment="Center" Margin="5 0 0 0" />
                                         <Button Name="NameRandomize" Text="{Loc 'humanoid-profile-editor-name-random-button'}" />
                                     </BoxContainer>
-                                    <Button Name="RandomizeEverythingButton" HorizontalAlignment="Center"
-                                            HorizontalExpand="False" MaxWidth="256"
-                                            Text="{Loc 'humanoid-profile-editor-randomize-everything-button'}" />
+                                    <!-- MACRO START: AppearanceRandomize button -->
+                                     <BoxContainer Orientation="Horizontal" VerticalExpand="True">
+                                        <Button Name="RandomizeAppearanceButton" HorizontalAlignment="Center"
+                                                HorizontalExpand="False" MaxWidth="256"
+                                                Text="{Loc 'humanoid-profile-editor-randomize-appearance-button'}" />
+                                        <!-- also moving upstream's button in this BoxContainer. -->
+                                        <Button Name="RandomizeEverythingButton" HorizontalAlignment="Center"
+                                                HorizontalExpand="False" MaxWidth="256"
+                                                Text="{Loc 'humanoid-profile-editor-randomize-everything-button'}" />
+                                    </BoxContainer>
+                                    <!-- MACRO END -->
                                     <RichTextLabel Name="WarningLabel" HorizontalExpand="False"
                                                    VerticalExpand="True" MaxWidth="425"
                                                    HorizontalAlignment="Left" />

--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
@@ -146,6 +146,7 @@ namespace Content.Client.Lobby.UI
             NameEdit.IsValid = args => args.Length <= _maxNameLength;
             NameRandomize.OnPressed += args => RandomizeName();
             RandomizeEverythingButton.OnPressed += args => { RandomizeEverything(); };
+            RandomizeAppearanceButton.OnPressed += args => { RandomizeAppearance(); }; // MACRO: Random appearance
             WarningLabel.SetMarkup($"[color=red]{Loc.GetString("humanoid-profile-editor-naming-rules-warning")}[/color]");
 
             #endregion Name

--- a/Content.Shared/Humanoid/HumanoidCharacterAppearance.cs
+++ b/Content.Shared/Humanoid/HumanoidCharacterAppearance.cs
@@ -139,7 +139,6 @@ public sealed partial class HumanoidCharacterAppearance : IEquatable<HumanoidCha
                 layerMarkings.Add(layer, PickLayerRandomMarkings(layer, layerLimits, allMarkings, colorPalette));
             }
             newMarkings.Add(organ, layerMarkings);
-            layerMarkings.Clear();
         }
 
         HumanoidCharacterAppearance appearance = new(

--- a/Content.Shared/Humanoid/HumanoidCharacterAppearance.cs
+++ b/Content.Shared/Humanoid/HumanoidCharacterAppearance.cs
@@ -94,17 +94,10 @@ public sealed partial class HumanoidCharacterAppearance : IEquatable<HumanoidCha
         // Upstream behaviour is commented out. This is a bit messy, sorry!!!
 
         // var newEyeColor = random.Pick(_realisticEyeColors);
-        var baseColor = new Color(random.NextFloat(1), random.NextFloat(1), random.NextFloat(1), 1);
-
-        // COLORPALETTE NOTES! (TODO maybe make this a dict? hashset?)
-        // 0 is skin color (base color)
-        // 1 is hair color
-        // 2 is eye color
-        var colorPalette = GetPaletteFromBase(baseColor, random.Next(3));
 
         var protoMan = IoCManager.Resolve<IPrototypeManager>();
         var skinType = protoMan.Index<SpeciesPrototype>(species).SkinColoration;
-        // var strategy = protoMan.Index(skinType).Strategy;
+        var strategy = protoMan.Index(skinType).Strategy;
 
         // var newSkinColor = strategy.InputType switch
         // {
@@ -112,74 +105,48 @@ public sealed partial class HumanoidCharacterAppearance : IEquatable<HumanoidCha
         //     SkinColorationStrategyInput.Color => strategy.ClosestSkinColor(new Color(random.NextFloat(1), random.NextFloat(1), random.NextFloat(1), 1)),
         //     _ => strategy.ClosestSkinColor(new Color(random.NextFloat(1), random.NextFloat(1), random.NextFloat(1), 1)),
         // };
+
+        var baseColor = new Color(random.NextFloat(1), random.NextFloat(1), random.NextFloat(1), 1);
+        var colorPalette = GetPaletteFromBase(baseColor, random.Next(3));
+
+        // TODO MAKE THIS BETTER
         colorPalette = ClampPaletteToStrategy(colorPalette, protoMan.Index(skinType));
+        var newSkinColor = colorPalette[0];
+        // var newHairColor = colorPalette[1];
+        var newEyeColor = colorPalette[2];
 
         var markingData = markingManager.GetMarkingData(species);
-        var layers = new HashSet<HumanoidVisualLayers>();
         Dictionary<ProtoId<OrganCategoryPrototype>, Dictionary<HumanoidVisualLayers, List<Marking>>> newMarkings = [];
 
-        // code below is modified from MarkingPicker and OrganMarkingPicker
         foreach (var (organ, organData) in markingData)
         {
+            // if this is an organ with no markings (heart, stomach, etc)
+            if (!protoMan.TryIndex(organData.Group, out var groupProto))
+                continue;
+
             Dictionary<HumanoidVisualLayers, List<Marking>> layerMarkings = [];
-            foreach (var layer in layers)
+            foreach (var layer in organData.Layers)
             {
                 var allMarkings = markingManager.MarkingsByLayerAndGroupAndSex(layer, organData.Group, sex);
 
                 if (allMarkings.Count == 0)
                     continue;
 
-                var markingWeights = new Dictionary<string, float>();
-                foreach (var marking in allMarkings)
-                    markingWeights.Add(marking.Key, marking.Value.RandomWeight);
-
-                // add random markings!
-                // this will roll once for each point in the marking category.
-                var markingGroup = protoMan.Index(organData.Group);
-
-                if (!markingGroup.Limits.ContainsKey(layer))
+                var layerLimits = groupProto.Limits.GetValueOrDefault(layer);
+                if (layerLimits is null || layerLimits.Limit <= 0)
                     continue;
 
-                List<Marking> groupMarkings = [];
-                for (var i = 0; i < markingGroup.Limits[layer].Limit; i++)
-                {
-                    // just in case there are somehow more points than markings
-                    if (markingWeights.Count == 0)
-                        continue;
-
-                    // category roll to see if we add anything
-                    if (!random.Prob(markingGroup.Limits[layer].Weight))
-                        continue;
-
-                    var randomMarking = random.Pick(markingWeights).Key;
-
-                    if (!allMarkings.TryGetValue(randomMarking, out var protoToAdd))
-                        continue;
-
-                    var markingToAdd = protoToAdd.AsMarking();
-                    // prevent duplicates
-                    markingWeights.Remove(randomMarking);
-
-                    // TODO: we may need some color validation here. unsure.
-
-                    // select a random color from our two secondary colors.
-                    var markingColor = random.Pick(colorPalette.Skip(0).ToList());
-
-                    // TODO: multiple layers on a marking?
-                    markingToAdd.WithColor(markingColor);
-
-                    groupMarkings.Add(markingToAdd);
-                }
-                layerMarkings.Add(layer, groupMarkings);
-                groupMarkings.Clear();
+                layerMarkings.Add(layer, PickLayerRandomMarkings(layer, layerLimits, allMarkings, colorPalette));
             }
             newMarkings.Add(organ, layerMarkings);
             layerMarkings.Clear();
         }
-        return new HumanoidCharacterAppearance(
-            colorPalette[2],
-            colorPalette[0],
+
+        HumanoidCharacterAppearance appearance = new(
+            newEyeColor,
+            newSkinColor,
             newMarkings);
+        return EnsureValid(appearance, species, sex);
         // return new HumanoidCharacterAppearance(newEyeColor, newSkinColor, new());
         // MACRO END (whew!)
     }

--- a/Content.Shared/Humanoid/HumanoidCharacterAppearance.cs
+++ b/Content.Shared/Humanoid/HumanoidCharacterAppearance.cs
@@ -93,7 +93,7 @@ public sealed partial class HumanoidCharacterAppearance : IEquatable<HumanoidCha
         // MACRO START: random markings :)
         // Upstream behaviour is commented out. This is a bit messy, sorry!!!
 
-        List<Marking> newMarkings = [];
+        // var newEyeColor = random.Pick(_realisticEyeColors);
         var baseColor = new Color(random.NextFloat(1), random.NextFloat(1), random.NextFloat(1), 1);
 
         // COLORPALETTE NOTES! (TODO maybe make this a dict? hashset?)
@@ -102,11 +102,9 @@ public sealed partial class HumanoidCharacterAppearance : IEquatable<HumanoidCha
         // 2 is eye color
         var colorPalette = GetPaletteFromBase(baseColor, random.Next(3));
 
-        // var newEyeColor = random.Pick(_realisticEyeColors);
-
         var protoMan = IoCManager.Resolve<IPrototypeManager>();
         var skinType = protoMan.Index<SpeciesPrototype>(species).SkinColoration;
-        var strategy = protoMan.Index(skinType).Strategy;
+        // var strategy = protoMan.Index(skinType).Strategy;
 
         // var newSkinColor = strategy.InputType switch
         // {
@@ -114,114 +112,75 @@ public sealed partial class HumanoidCharacterAppearance : IEquatable<HumanoidCha
         //     SkinColorationStrategyInput.Color => strategy.ClosestSkinColor(new Color(random.NextFloat(1), random.NextFloat(1), random.NextFloat(1), 1)),
         //     _ => strategy.ClosestSkinColor(new Color(random.NextFloat(1), random.NextFloat(1), random.NextFloat(1), 1)),
         // };
-
         colorPalette = ClampPaletteToStrategy(colorPalette, protoMan.Index(skinType));
 
-        // declare our default hair.
-        var newHairStyle = HairStyles.DefaultFacialHairStyle.Id;
-        var newFacialHairStyle = HairStyles.DefaultFacialHairStyle.Id;
-
-        // we're also grabbing a new dictionary to store our marking data on a per-organ basis.
-        var markingSet = markingManager.GetMarkingData(species);
-
-        // now we need to somehow get from our species to a single visual layer and marking group. the only way we can do this? organs.
+        var markingData = markingManager.GetMarkingData(species);
         var layers = new HashSet<HumanoidVisualLayers>();
-        foreach (var category in layers)
+        Dictionary<ProtoId<OrganCategoryPrototype>, Dictionary<HumanoidVisualLayers, List<Marking>>> newMarkings = [];
+
+        // code below is modified from MarkingPicker and OrganMarkingPicker
+        foreach (var (organ, organData) in markingData)
         {
-            // identify what marking group we're using for this layer,
-            if (!markingSet.TryGetValue(category, out var markingData))
+            Dictionary<HumanoidVisualLayers, List<Marking>> layerMarkings = [];
+            foreach (var layer in layers)
             {
-                break;
-            }
+                var allMarkings = markingManager.MarkingsByLayerAndGroupAndSex(layer, organData.Group, sex);
 
-            // grab a dictionary of markings in that layer for that marking group,
-            var markings = markingManager.MarkingsByLayerAndGroupAndSex(category, markingData.Group, sex);
+                if (allMarkings.Count == 0)
+                    continue;
 
-            // and make a new dictionary that stores the string of the marking and the corresponding random weight.
-            var markingWeights = new Dictionary<string, float>();
-            foreach (var marking in markings)
-                markingWeights.Add(marking.Key, marking.Value.RandomWeight);
+                var markingWeights = new Dictionary<string, float>();
+                foreach (var marking in allMarkings)
+                    markingWeights.Add(marking.Key, marking.Value.RandomWeight);
 
-            // grab the markingset from our category..
-            if (!markingSet.TryGetValue(category, out var categorySet))
-                continue;
-
-            // hair and facial hair are handled different to other markings, so those get their own special treatment
-            // if it's hair, and there are hair styles, roll one. else bald
-            else if (category == HumanoidVisualLayers.Hair)
-            {
-                newHairStyle = markings.Count == 0 || !random.Prob(categorySet.Weight)
-                    ? HairStyles.DefaultHairStyle.Id
-                    : random.Pick(markingWeights).Key;
-            }
-
-            // if it's facial hair, there are entries in the category, and the character is not female, roll & assign a random one. else bald
-            else if (category == HumanoidVisualLayers.FacialHair)
-            {
-                newFacialHairStyle = markings.Count == 0 || sex == Sex.Female || !random.Prob(categorySet.Weight)
-                    ? HairStyles.DefaultFacialHairStyle.Id
-                    : random.Pick(markingWeights).Key;
-            }
-
-            // for every other category,
-            else if (markings.Keys.Any())
-            {
                 // add random markings!
                 // this will roll once for each point in the marking category.
-                for (var i = 0; i < categorySet.Limit; i++)
+                var markingGroup = protoMan.Index(organData.Group);
+
+                if (!markingGroup.Limits.ContainsKey(layer))
+                    continue;
+
+                List<Marking> groupMarkings = [];
+                for (var i = 0; i < markingGroup.Limits[layer].Limit; i++)
                 {
                     // just in case there are somehow more points than markings
                     if (markingWeights.Count == 0)
                         continue;
 
                     // category roll to see if we add anything
-                    if (!random.Prob(categorySet.Weight))
+                    if (!random.Prob(markingGroup.Limits[layer].Weight))
                         continue;
 
-                    // pick a random marking from the list
                     var randomMarking = random.Pick(markingWeights).Key;
-                    if (!markings.TryGetValue(randomMarking, out var protoToAdd))
-                        continue;
-                    var markingToAdd = protoToAdd.AsMarking();
-                    Color markingColor;
 
+                    if (!allMarkings.TryGetValue(randomMarking, out var protoToAdd))
+                        continue;
+
+                    var markingToAdd = protoToAdd.AsMarking();
                     // prevent duplicates
                     markingWeights.Remove(randomMarking);
 
-                    // set gauze to white.
-                    // side note, I really hate that gauze isn't its own category. please fix that so that i can make this not suck as much.
-                    // or, like, give it its own color rules. or something.
-                    if (markingToAdd.MarkingId.Contains("gauze", StringComparison.OrdinalIgnoreCase))
-                    {
-                        markingToAdd.SetColor(Color.White);
-                        newMarkings.Add(markingToAdd);
-                        continue;
-                    }
+                    // TODO: we may need some color validation here. unsure.
 
-                    // select a random color from our two secondary colors. if our marking is a Tail, add the skin color as well, otherwise lizards always look a little odd.
-                    // this will also make moths and spiders look less interesting on average, but I don't want a hardcoded exception for lizards.
-                    if (category == HumanoidVisualLayers.Tail)
-                        markingColor = random.Pick(colorPalette);
-                    else
-                        markingColor = random.Pick(colorPalette.Skip(0).ToList());
+                    // select a random color from our two secondary colors.
+                    var markingColor = random.Pick(colorPalette.Skip(0).ToList());
 
-                    // set the marking to that color
-                    markingToAdd.SetColor(markingColor);
+                    // TODO: multiple layers on a marking?
+                    markingToAdd.WithColor(markingColor);
 
-                    // otherwise, add it to the final list.
-                    newMarkings.Add(markingToAdd);
+                    groupMarkings.Add(markingToAdd);
                 }
+                layerMarkings.Add(layer, groupMarkings);
+                groupMarkings.Clear();
             }
+            newMarkings.Add(organ, layerMarkings);
+            layerMarkings.Clear();
         }
-
-        // at the end of all that, we should have new values for each of these, so we set the character appearance to these new values.
         return new HumanoidCharacterAppearance(
             colorPalette[2],
             colorPalette[0],
             newMarkings);
-
         // return new HumanoidCharacterAppearance(newEyeColor, newSkinColor, new());
-
         // MACRO END (whew!)
     }
 

--- a/Content.Shared/Humanoid/HumanoidCharacterAppearance.cs
+++ b/Content.Shared/Humanoid/HumanoidCharacterAppearance.cs
@@ -91,37 +91,22 @@ public sealed partial class HumanoidCharacterAppearance : IEquatable<HumanoidCha
         // TODO: Add random markings
 
         // MACRO START: random markings :)
-        // Note that a lot of this code is modified from upstream, so some code is shared. Anything commented out is from upstream.
+        // Upstream behaviour is commented out. This is a bit messy, sorry!!!
 
         List<Marking> newMarkings = [];
-
-        // grab a completely random color.
         var baseColor = new Color(random.NextFloat(1), random.NextFloat(1), random.NextFloat(1), 1);
 
-        // create a new color palette based on BaseColor. roll to determine what type of palette it is.
-        // personally I think this should be weighted, but I can't be bothered to implement that.
-        List<Color> colorPalette = [];
-        switch (random.Next(3))
-        {
-            case 0:
-                colorPalette = GetSplitComplementaries(baseColor);
-                break;
-            case 1:
-                colorPalette = GetTriadicComplementaries(baseColor);
-                break;
-            case 2:
-                colorPalette = GetOneComplementary(baseColor);
-                break;
-        }
+        // COLORPALETTE NOTES! (TODO maybe make this a dict? hashset?)
+        // 0 is skin color (base color)
+        // 1 is hair color
+        // 2 is eye color
+        var colorPalette = GetPaletteFromBase(baseColor, random.Next(3));
 
         // var newEyeColor = random.Pick(_realisticEyeColors);
 
-        // grab the skin type, and clamp it to our colour strategy.
         var protoMan = IoCManager.Resolve<IPrototypeManager>();
         var skinType = protoMan.Index<SpeciesPrototype>(species).SkinColoration;
         var strategy = protoMan.Index(skinType).Strategy;
-
-        var newSkinColor = strategy.ClosestSkinColor(colorPalette[0]);
 
         // var newSkinColor = strategy.InputType switch
         // {
@@ -130,35 +115,7 @@ public sealed partial class HumanoidCharacterAppearance : IEquatable<HumanoidCha
         //     _ => strategy.ClosestSkinColor(new Color(random.NextFloat(1), random.NextFloat(1), random.NextFloat(1), 1)),
         // };
 
-        // declare some defaults. ensures that the hair and eyes on hues-colored species don't match the skin or one another.
-        var newHairColor = colorPalette[1];
-        var newEyeColor = colorPalette[2];
-
-        // now we do some color logic.
-        if (protoMan.Index(skinType).RealisticColors)
-        {
-            // pick a random realistic hair color from the list and randomize it juuuuust a little bit.
-            newHairColor = random.Pick(HairStyles.RealisticHairColors);
-            newHairColor = newHairColor
-                .WithRed(RandomizeColor(newHairColor.R))
-                .WithGreen(RandomizeColor(newHairColor.G))
-                .WithBlue(RandomizeColor(newHairColor.B));
-
-            // and pick a random realistic eye color from the list.
-            newEyeColor = random.Pick(_realisticEyeColors);
-
-            // we're also going to crush the other colors down to the skin's luminosity so markings don't appear too bright on darker skin.
-            // (mq comment- is this needed? could look cool without. maybe a bool?)
-            colorPalette[1] = SquashToSkinLuminosity(newSkinColor, colorPalette[1]);
-            colorPalette[2] = SquashToSkinLuminosity(newSkinColor, colorPalette[2]);
-        }
-
-        if (protoMan.Index(skinType).SquashAllColors)
-        {
-            // crush the other colors down to valid skin colors.
-            colorPalette[1] = strategy.ClosestSkinColor(colorPalette[1]);
-            colorPalette[2] = strategy.ClosestSkinColor(colorPalette[2]);
-        }
+        colorPalette = ClampPaletteToStrategy(colorPalette, protoMan.Index(skinType));
 
         // declare our default hair.
         var newHairStyle = HairStyles.DefaultFacialHairStyle.Id;
@@ -167,10 +124,9 @@ public sealed partial class HumanoidCharacterAppearance : IEquatable<HumanoidCha
         // we're also grabbing a new dictionary to store our marking data on a per-organ basis.
         var markingSet = markingManager.GetMarkingData(species);
 
-        // nubody made this logic suck so bad im so sorry.
         // now we need to somehow get from our species to a single visual layer and marking group. the only way we can do this? organs.
-        // GOD I NEED A FUCKING API
-        foreach (var category in protoMan.EnumeratePrototypes<OrganCategoryPrototype>())
+        var layers = new HashSet<HumanoidVisualLayers>();
+        foreach (var category in layers)
         {
             // identify what marking group we're using for this layer,
             if (!markingSet.TryGetValue(category, out var markingData))
@@ -259,72 +215,13 @@ public sealed partial class HumanoidCharacterAppearance : IEquatable<HumanoidCha
         }
 
         // at the end of all that, we should have new values for each of these, so we set the character appearance to these new values.
-        return new HumanoidCharacterAppearance(newHairStyle, newHairColor, newFacialHairStyle, newHairColor, newEyeColor, newSkinColor, newMarkings);
+        return new HumanoidCharacterAppearance(
+            colorPalette[2],
+            colorPalette[0],
+            newMarkings);
 
         // return new HumanoidCharacterAppearance(newEyeColor, newSkinColor, new());
 
-        // HELPER FUNCTIONS
-        // These are probably better off in Robust.Shared.Maths.Color. oh well
-
-        float RandomizeColor(float channel)
-        {
-            return MathHelper.Clamp01(channel + random.Next(-25, 25) / 100f);
-        }
-
-        List<Color> GetComplementaryColors(Color color, double angle)
-        {
-            var hsl = Color.ToHsl(color);
-
-            // sorry about how messy these are, but to get all random values we need to reroll for positive and negative HSL.
-            var hVal = hsl.X + angle;
-            hVal = hVal >= 0.360 ? hVal - 0.360 : hVal;
-            var positiveHSL = new Vector4((float)hVal, MathHelper.Clamp01(hsl.Y + random.Next(-20, 0) / 100f), MathHelper.Clamp01(hsl.Z + random.Next(-15, 15) / 100f), hsl.W);
-
-            var hVal1 = hsl.X - angle;
-            hVal1 = hVal1 <= 0 ? hVal1 + 0.360 : hVal1;
-            var negativeHSL = new Vector4((float)hVal1, MathHelper.Clamp01(hsl.Y + random.Next(-20, 0) / 100f), MathHelper.Clamp01(hsl.Z + random.Next(-15, 15) / 100f), hsl.W);
-
-            var c0 = Color.FromHsl(positiveHSL);
-            var c1 = Color.FromHsl(negativeHSL);
-
-            var palette = new List<Color> { color, c0, c1 };
-            return palette;
-        }
-
-        //return a list of triadic complementary colors
-        List<Color> GetTriadicComplementaries(Color color)
-        {
-            return GetComplementaryColors(color, 0.120);
-        }
-
-        // return a list of split complementary colors
-        List<Color> GetSplitComplementaries(Color color)
-        {
-            return GetComplementaryColors(color, 0.150);
-        }
-
-        // return a list containing the base color and two copies of a single complemenary color
-        List<Color> GetOneComplementary(Color color)
-        {
-            return GetComplementaryColors(color, 0.180);
-        }
-
-        Color SquashToSkinLuminosity(Color skinColor, Color toSquash)
-        {
-            var skinColorHSL = Color.ToHsl(skinColor);
-            var toSquashHSL = Color.ToHsl(toSquash);
-
-            // check if the skin color is as dark as or darker than the marking color:
-            if (toSquashHSL.Z <= skinColorHSL.Z)
-            {
-                // if it is, don't fuck with it
-                return toSquash;
-            }
-
-            // otherwise, create a new color with the H, S, and A of toSquash, but the L of skinColor
-            var newColor = new Vector4(toSquashHSL.X, toSquashHSL.Y, skinColorHSL.Z, toSquashHSL.W);
-            return Color.FromHsl(newColor);
-        }
         // MACRO END (whew!)
     }
 

--- a/Content.Shared/Humanoid/HumanoidCharacterAppearance.cs
+++ b/Content.Shared/Humanoid/HumanoidCharacterAppearance.cs
@@ -109,11 +109,12 @@ public sealed partial class HumanoidCharacterAppearance : IEquatable<HumanoidCha
         var baseColor = new Color(random.NextFloat(1), random.NextFloat(1), random.NextFloat(1), 1);
         var colorPalette = GetPaletteFromBase(baseColor, random.Next(3));
 
-        // TODO MAKE THIS BETTER
+        // TODO MAKE THIS BETTER. SORRY!!!
         colorPalette = ClampPaletteToStrategy(colorPalette, protoMan.Index(skinType));
         var newSkinColor = colorPalette[0];
         // var newHairColor = colorPalette[1];
         var newEyeColor = colorPalette[2];
+        colorPalette.Remove(newSkinColor);
 
         var markingData = markingManager.GetMarkingData(species);
         Dictionary<ProtoId<OrganCategoryPrototype>, Dictionary<HumanoidVisualLayers, List<Marking>>> newMarkings = [];

--- a/Content.Shared/Humanoid/HumanoidCharacterAppearance.cs
+++ b/Content.Shared/Humanoid/HumanoidCharacterAppearance.cs
@@ -109,12 +109,7 @@ public sealed partial class HumanoidCharacterAppearance : IEquatable<HumanoidCha
         var baseColor = new Color(random.NextFloat(1), random.NextFloat(1), random.NextFloat(1), 1);
         var colorPalette = GetPaletteFromBase(baseColor, random.Next(3));
 
-        // TODO MAKE THIS BETTER. SORRY!!!
-        colorPalette = ClampPaletteToStrategy(colorPalette, protoMan.Index(skinType));
-        var newSkinColor = colorPalette[0];
-        // var newHairColor = colorPalette[1];
-        var newEyeColor = colorPalette[2];
-        colorPalette.Remove(newSkinColor);
+        var colorDict = ClampPaletteToStrategy(colorPalette, protoMan.Index(skinType));
 
         var markingData = markingManager.GetMarkingData(species);
         Dictionary<ProtoId<OrganCategoryPrototype>, Dictionary<HumanoidVisualLayers, List<Marking>>> newMarkings = [];
@@ -137,14 +132,14 @@ public sealed partial class HumanoidCharacterAppearance : IEquatable<HumanoidCha
                 if (layerLimits is null || layerLimits.Limit <= 0)
                     continue;
 
-                layerMarkings.Add(layer, PickLayerRandomMarkings(layer, layerLimits, allMarkings, colorPalette));
+                layerMarkings.Add(layer, PickLayerRandomMarkings(layer, layerLimits, allMarkings, colorDict));
             }
             newMarkings.Add(organ, layerMarkings);
         }
 
         HumanoidCharacterAppearance appearance = new(
-            newEyeColor,
-            newSkinColor,
+            colorDict.GetValueOrDefault(EyeColorKey),
+            colorDict.GetValueOrDefault(SkinColorKey),
             newMarkings);
         return EnsureValid(appearance, species, sex);
         // return new HumanoidCharacterAppearance(newEyeColor, newSkinColor, new());

--- a/Content.Shared/Humanoid/HumanoidCharacterAppearance.cs
+++ b/Content.Shared/Humanoid/HumanoidCharacterAppearance.cs
@@ -90,20 +90,242 @@ public sealed partial class HumanoidCharacterAppearance : IEquatable<HumanoidCha
 
         // TODO: Add random markings
 
-        var newEyeColor = random.Pick(_realisticEyeColors);
+        // MACRO START: random markings :)
+        // Note that a lot of this code is modified from upstream, so some code is shared. Anything commented out is from upstream.
 
+        List<Marking> newMarkings = [];
+
+        // grab a completely random color.
+        var baseColor = new Color(random.NextFloat(1), random.NextFloat(1), random.NextFloat(1), 1);
+
+        // create a new color palette based on BaseColor. roll to determine what type of palette it is.
+        // personally I think this should be weighted, but I can't be bothered to implement that.
+        List<Color> colorPalette = [];
+        switch (random.Next(3))
+        {
+            case 0:
+                colorPalette = GetSplitComplementaries(baseColor);
+                break;
+            case 1:
+                colorPalette = GetTriadicComplementaries(baseColor);
+                break;
+            case 2:
+                colorPalette = GetOneComplementary(baseColor);
+                break;
+        }
+
+        // var newEyeColor = random.Pick(_realisticEyeColors);
+
+        // grab the skin type, and clamp it to our colour strategy.
         var protoMan = IoCManager.Resolve<IPrototypeManager>();
         var skinType = protoMan.Index<SpeciesPrototype>(species).SkinColoration;
         var strategy = protoMan.Index(skinType).Strategy;
 
-        var newSkinColor = strategy.InputType switch
-        {
-            SkinColorationStrategyInput.Unary => strategy.FromUnary(random.NextFloat(0f, 100f)),
-            SkinColorationStrategyInput.Color => strategy.ClosestSkinColor(new Color(random.NextFloat(1), random.NextFloat(1), random.NextFloat(1), 1)),
-            _ => strategy.ClosestSkinColor(new Color(random.NextFloat(1), random.NextFloat(1), random.NextFloat(1), 1)),
-        };
+        var newSkinColor = strategy.ClosestSkinColor(colorPalette[0]);
 
-        return new HumanoidCharacterAppearance(newEyeColor, newSkinColor, new());
+        // var newSkinColor = strategy.InputType switch
+        // {
+        //     SkinColorationStrategyInput.Unary => strategy.FromUnary(random.NextFloat(0f, 100f)),
+        //     SkinColorationStrategyInput.Color => strategy.ClosestSkinColor(new Color(random.NextFloat(1), random.NextFloat(1), random.NextFloat(1), 1)),
+        //     _ => strategy.ClosestSkinColor(new Color(random.NextFloat(1), random.NextFloat(1), random.NextFloat(1), 1)),
+        // };
+
+        // declare some defaults. ensures that the hair and eyes on hues-colored species don't match the skin or one another.
+        var newHairColor = colorPalette[1];
+        var newEyeColor = colorPalette[2];
+
+        // now we do some color logic.
+        if (protoMan.Index(skinType).RealisticColors)
+        {
+            // pick a random realistic hair color from the list and randomize it juuuuust a little bit.
+            newHairColor = random.Pick(HairStyles.RealisticHairColors);
+            newHairColor = newHairColor
+                .WithRed(RandomizeColor(newHairColor.R))
+                .WithGreen(RandomizeColor(newHairColor.G))
+                .WithBlue(RandomizeColor(newHairColor.B));
+
+            // and pick a random realistic eye color from the list.
+            newEyeColor = random.Pick(_realisticEyeColors);
+
+            // we're also going to crush the other colors down to the skin's luminosity so markings don't appear too bright on darker skin.
+            // (mq comment- is this needed? could look cool without. maybe a bool?)
+            colorPalette[1] = SquashToSkinLuminosity(newSkinColor, colorPalette[1]);
+            colorPalette[2] = SquashToSkinLuminosity(newSkinColor, colorPalette[2]);
+        }
+
+        if (protoMan.Index(skinType).SquashAllColors)
+        {
+            // crush the other colors down to valid skin colors.
+            colorPalette[1] = strategy.ClosestSkinColor(colorPalette[1]);
+            colorPalette[2] = strategy.ClosestSkinColor(colorPalette[2]);
+        }
+
+        // declare our default hair.
+        var newHairStyle = HairStyles.DefaultFacialHairStyle.Id;
+        var newFacialHairStyle = HairStyles.DefaultFacialHairStyle.Id;
+
+        // we're also grabbing a new dictionary to store our marking data on a per-organ basis.
+        var markingSet = markingManager.GetMarkingData(species);
+
+        // nubody made this logic suck so bad im so sorry.
+        // now we need to somehow get from our species to a single visual layer and marking group. the only way we can do this? organs.
+        // GOD I NEED A FUCKING API
+        foreach (var category in protoMan.EnumeratePrototypes<OrganCategoryPrototype>())
+        {
+            // identify what marking group we're using for this layer,
+            if (!markingSet.TryGetValue(category, out var markingData))
+            {
+                break;
+            }
+
+            // grab a dictionary of markings in that layer for that marking group,
+            var markings = markingManager.MarkingsByLayerAndGroupAndSex(category, markingData.Group, sex);
+
+            // and make a new dictionary that stores the string of the marking and the corresponding random weight.
+            var markingWeights = new Dictionary<string, float>();
+            foreach (var marking in markings)
+                markingWeights.Add(marking.Key, marking.Value.RandomWeight);
+
+            // grab the markingset from our category..
+            if (!markingSet.TryGetValue(category, out var categorySet))
+                continue;
+
+            // hair and facial hair are handled different to other markings, so those get their own special treatment
+            // if it's hair, and there are hair styles, roll one. else bald
+            else if (category == HumanoidVisualLayers.Hair)
+            {
+                newHairStyle = markings.Count == 0 || !random.Prob(categorySet.Weight)
+                    ? HairStyles.DefaultHairStyle.Id
+                    : random.Pick(markingWeights).Key;
+            }
+
+            // if it's facial hair, there are entries in the category, and the character is not female, roll & assign a random one. else bald
+            else if (category == HumanoidVisualLayers.FacialHair)
+            {
+                newFacialHairStyle = markings.Count == 0 || sex == Sex.Female || !random.Prob(categorySet.Weight)
+                    ? HairStyles.DefaultFacialHairStyle.Id
+                    : random.Pick(markingWeights).Key;
+            }
+
+            // for every other category,
+            else if (markings.Keys.Any())
+            {
+                // add random markings!
+                // this will roll once for each point in the marking category.
+                for (var i = 0; i < categorySet.Limit; i++)
+                {
+                    // just in case there are somehow more points than markings
+                    if (markingWeights.Count == 0)
+                        continue;
+
+                    // category roll to see if we add anything
+                    if (!random.Prob(categorySet.Weight))
+                        continue;
+
+                    // pick a random marking from the list
+                    var randomMarking = random.Pick(markingWeights).Key;
+                    if (!markings.TryGetValue(randomMarking, out var protoToAdd))
+                        continue;
+                    var markingToAdd = protoToAdd.AsMarking();
+                    Color markingColor;
+
+                    // prevent duplicates
+                    markingWeights.Remove(randomMarking);
+
+                    // set gauze to white.
+                    // side note, I really hate that gauze isn't its own category. please fix that so that i can make this not suck as much.
+                    // or, like, give it its own color rules. or something.
+                    if (markingToAdd.MarkingId.Contains("gauze", StringComparison.OrdinalIgnoreCase))
+                    {
+                        markingToAdd.SetColor(Color.White);
+                        newMarkings.Add(markingToAdd);
+                        continue;
+                    }
+
+                    // select a random color from our two secondary colors. if our marking is a Tail, add the skin color as well, otherwise lizards always look a little odd.
+                    // this will also make moths and spiders look less interesting on average, but I don't want a hardcoded exception for lizards.
+                    if (category == HumanoidVisualLayers.Tail)
+                        markingColor = random.Pick(colorPalette);
+                    else
+                        markingColor = random.Pick(colorPalette.Skip(0).ToList());
+
+                    // set the marking to that color
+                    markingToAdd.SetColor(markingColor);
+
+                    // otherwise, add it to the final list.
+                    newMarkings.Add(markingToAdd);
+                }
+            }
+        }
+
+        // at the end of all that, we should have new values for each of these, so we set the character appearance to these new values.
+        return new HumanoidCharacterAppearance(newHairStyle, newHairColor, newFacialHairStyle, newHairColor, newEyeColor, newSkinColor, newMarkings);
+
+        // return new HumanoidCharacterAppearance(newEyeColor, newSkinColor, new());
+
+        // HELPER FUNCTIONS
+        // These are probably better off in Robust.Shared.Maths.Color. oh well
+
+        float RandomizeColor(float channel)
+        {
+            return MathHelper.Clamp01(channel + random.Next(-25, 25) / 100f);
+        }
+
+        List<Color> GetComplementaryColors(Color color, double angle)
+        {
+            var hsl = Color.ToHsl(color);
+
+            // sorry about how messy these are, but to get all random values we need to reroll for positive and negative HSL.
+            var hVal = hsl.X + angle;
+            hVal = hVal >= 0.360 ? hVal - 0.360 : hVal;
+            var positiveHSL = new Vector4((float)hVal, MathHelper.Clamp01(hsl.Y + random.Next(-20, 0) / 100f), MathHelper.Clamp01(hsl.Z + random.Next(-15, 15) / 100f), hsl.W);
+
+            var hVal1 = hsl.X - angle;
+            hVal1 = hVal1 <= 0 ? hVal1 + 0.360 : hVal1;
+            var negativeHSL = new Vector4((float)hVal1, MathHelper.Clamp01(hsl.Y + random.Next(-20, 0) / 100f), MathHelper.Clamp01(hsl.Z + random.Next(-15, 15) / 100f), hsl.W);
+
+            var c0 = Color.FromHsl(positiveHSL);
+            var c1 = Color.FromHsl(negativeHSL);
+
+            var palette = new List<Color> { color, c0, c1 };
+            return palette;
+        }
+
+        //return a list of triadic complementary colors
+        List<Color> GetTriadicComplementaries(Color color)
+        {
+            return GetComplementaryColors(color, 0.120);
+        }
+
+        // return a list of split complementary colors
+        List<Color> GetSplitComplementaries(Color color)
+        {
+            return GetComplementaryColors(color, 0.150);
+        }
+
+        // return a list containing the base color and two copies of a single complemenary color
+        List<Color> GetOneComplementary(Color color)
+        {
+            return GetComplementaryColors(color, 0.180);
+        }
+
+        Color SquashToSkinLuminosity(Color skinColor, Color toSquash)
+        {
+            var skinColorHSL = Color.ToHsl(skinColor);
+            var toSquashHSL = Color.ToHsl(toSquash);
+
+            // check if the skin color is as dark as or darker than the marking color:
+            if (toSquashHSL.Z <= skinColorHSL.Z)
+            {
+                // if it is, don't fuck with it
+                return toSquash;
+            }
+
+            // otherwise, create a new color with the H, S, and A of toSquash, but the L of skinColor
+            var newColor = new Vector4(toSquashHSL.X, toSquashHSL.Y, skinColorHSL.Z, toSquashHSL.W);
+            return Color.FromHsl(newColor);
+        }
+        // MACRO END (whew!)
     }
 
     public static Color ClampColor(Color color)

--- a/Content.Shared/Humanoid/Markings/MarkingColoring.cs
+++ b/Content.Shared/Humanoid/Markings/MarkingColoring.cs
@@ -89,13 +89,13 @@ public static class MarkingColoring
 public sealed partial class LayerColoringDefinition
 {
     [DataField("type")]
-    public LayerColoringType? Type = new ColoringTypes.SkinColoring();
+    public LayerColoringType? Type; //= new ColoringTypes.SkinColoring(); // MACRO remove
 
     /// <summary>
     ///     Coloring types that will be used if main coloring type will return nil
     /// </summary>
     [DataField("fallbackTypes")]
-    public List<LayerColoringType> FallbackTypes = new() {};
+    public List<LayerColoringType> FallbackTypes = new() { new ColoringTypes.SkinColoring() }; // MACRO: add new skincoloring
 
     /// <summary>
     ///     Color that will be used if coloring type and fallback type will return nil

--- a/Content.Shared/Humanoid/Markings/MarkingPrototype.cs
+++ b/Content.Shared/Humanoid/Markings/MarkingPrototype.cs
@@ -40,5 +40,15 @@ namespace Content.Shared.Humanoid.Markings
         {
             return new Marking(ID, Sprites.Count);
         }
+
+        // MACRO- random marking weights
+        /// <summary>
+        /// Chance this marking will be added by appearance randomizer.
+        /// </summary>
+        /// <remarks>
+        /// Default value is 1.
+        /// </remarks>
+        [DataField]
+        public float RandomWeight = 1f;
     }
 }

--- a/Content.Shared/Humanoid/Markings/MarkingsGroupPrototype.cs
+++ b/Content.Shared/Humanoid/Markings/MarkingsGroupPrototype.cs
@@ -77,7 +77,7 @@ public sealed partial class MarkingsLimits
     /// Chance for a randomly generated entity to spawn with a marking in this category.
     /// </summary>
     /// <remarks>
-    /// Does one roll for each point- eg. at 2 points with a .6 weight,
+    /// Does one roll for each point in limit- eg. at 2 points in limit with a .6 weight,
     /// you have a 16% chance of no marking, a 48% chance of one marking and a 36% chance of two markings.
     /// </remarks>
     [DataField]

--- a/Content.Shared/Humanoid/Markings/MarkingsGroupPrototype.cs
+++ b/Content.Shared/Humanoid/Markings/MarkingsGroupPrototype.cs
@@ -71,6 +71,17 @@ public sealed partial class MarkingsLimits
     /// </summary>
     [DataField]
     public List<ProtoId<MarkingPrototype>> NudityDefault = new();
+
+    // MACRO- weighted random markings
+    /// <summary>
+    /// Chance for a randomly generated entity to spawn with a marking in this category.
+    /// </summary>
+    /// <remarks>
+    /// Does one roll for each point- eg. at 2 points with a .6 weight,
+    /// you have a 16% chance of no marking, a 48% chance of one marking and a 36% chance of two markings.
+    /// </remarks>
+    [DataField]
+    public float Weight = 0.6f;
 }
 
 [DataDefinition]

--- a/Content.Shared/Humanoid/SkinColorationPrototype.cs
+++ b/Content.Shared/Humanoid/SkinColorationPrototype.cs
@@ -20,6 +20,22 @@ public sealed partial class SkinColorationPrototype : IPrototype
     /// </summary>
     [DataField(required: true)]
     public ISkinColorationStrategy Strategy = default!;
+
+    // MACRO START: Random appearance
+    /// <summary>
+    ///     If true, will randomly generate realistic hair and eye colors.
+    ///     Will also crush randomly generated colors down to the skin's luminosity
+    ///     so markings don't appear too bright on darker skin.
+    /// </summary>
+    [DataField]
+    public bool RealisticColors;
+
+    /// <summary>
+    ///     If true, will also squash hair and eye colors to the coloration strategy.
+    /// </summary>
+    [DataField]
+    public bool SquashAllColors;
+    // MACRO END
 }
 
 /// <summary>
@@ -128,7 +144,7 @@ public sealed partial class HumanTonedSkinColoration : ISkinColorationStrategy
 
     public Color ClosestSkinColor(Color color)
     {
-        return ValidHumanSkinTone;
+        return FromUnary(ToUnary(color)); // MACRO bugfix, ValidHumanSkinTone -> FromUnary
     }
 
     public Color FromUnary(float color)

--- a/Content.Shared/Preferences/HumanoidCharacterProfile.cs
+++ b/Content.Shared/Preferences/HumanoidCharacterProfile.cs
@@ -84,10 +84,10 @@ namespace Content.Shared.Preferences
         public int Age { get; set; } = 18;
 
         [DataField]
-        public Sex Sex { get; private set; } = Sex.Male;
+        public Sex Sex { get; set; } = Sex.Male; // MACRO random appearance: public set
 
         [DataField]
-        public Gender Gender { get; private set; } = Gender.Male;
+        public Gender Gender { get; set; } = Gender.Male; // MACRO random appearance: public set
 
         /// <summary>
         /// Stores markings, eye colors, etc for the profile.

--- a/Content.Shared/_MACRO/Humanoid/HumanoidCharacterAppearance.Random.cs
+++ b/Content.Shared/_MACRO/Humanoid/HumanoidCharacterAppearance.Random.cs
@@ -158,18 +158,6 @@ public sealed partial class HumanoidCharacterAppearance
             if (randomMarking is null || !pool.Remove(randomMarking, out var protoToAdd))
                 continue;
 
-            // OPTION 1: upstream coloring
-            //var colors = MarkingColoring.GetMarkingLayerColors(protoToAdd, palette.GetValueOrDefault(SkinColorKey), palette.GetValueOrDefault(EyeColorKey), outMarkings);
-
-            // OPTION 2: random coloring
-            // List<Color> colors = new();
-            // palette.Remove(SkinColorKey);
-            // foreach (var sprite in protoToAdd.Sprites)
-            // {
-            //     colors.Add(random.Pick(palette.Values));
-            // }
-
-            // OPTION 3: what if the joker could beatbox
             List<Color> colors = new();
             for (var j = 0; j < protoToAdd.Sprites.Count; j++)
             {
@@ -183,23 +171,24 @@ public sealed partial class HumanoidCharacterAppearance
                     _ => null
                 };
 
-                if (name == null ||
+                // if we dont have a coloring rule set for that layer,
+                // we'll generate a random tone from either hair or eye.
+
+                var coloringType = (name == null ||
                     protoToAdd.Coloring.Layers is not { } layers ||
-                    !layers.TryGetValue(name, out var layerColoring))
-                {
-                    colors.Add(protoToAdd.Coloring.Default.GetColor(
+                    !layers.TryGetValue(name, out var layerColoring)) ?
+                    protoToAdd.Coloring.Default : layerColoring;
+
+                var color = coloringType.Type is not null ?
+                        coloringType.GetColor(
                         palette.GetValueOrDefault(SkinColorKey),
                         palette.GetValueOrDefault(EyeColorKey),
-                        outMarkings));
-                    continue;
-                }
+                        outMarkings) :
+                        random.Pick(new List<Color> {
+                        palette.GetValueOrDefault(HairColorKey),
+                        palette.GetValueOrDefault(EyeColorKey)});
 
-                // and here is where i would put my layer rules
-                // IF THEY WERE SERIALIZABLE
-                colors.Add(layerColoring.GetColor(
-                    palette.GetValueOrDefault(SkinColorKey),
-                    palette.GetValueOrDefault(EyeColorKey),
-                    outMarkings));
+                colors.Add(color);
             }
 
             outMarkings.Add(new Marking(protoToAdd, colors));

--- a/Content.Shared/_MACRO/Humanoid/HumanoidCharacterAppearance.Random.cs
+++ b/Content.Shared/_MACRO/Humanoid/HumanoidCharacterAppearance.Random.cs
@@ -1,5 +1,4 @@
 using System.Numerics;
-using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 
 namespace Content.Shared.Humanoid;
@@ -94,6 +93,7 @@ public sealed partial class HumanoidCharacterAppearance : IEquatable<HumanoidCha
         var hsl = Color.ToHsl(color);
 
         // sorry about how messy these are, but to get all random values we need to reroll for positive and negative HSL.
+        // since we want to rotate x degrees around the colour wheel, we need to do so in both directions- doing x + x degrees will give us the wrong hue!
 
         var hVal = hsl.X + angle;
         hVal = hVal >= 0.360 ? hVal - 0.360 : hVal;

--- a/Content.Shared/_MACRO/Humanoid/HumanoidCharacterAppearance.Random.cs
+++ b/Content.Shared/_MACRO/Humanoid/HumanoidCharacterAppearance.Random.cs
@@ -1,4 +1,8 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Numerics;
+using Content.Shared.Humanoid.Markings;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 
 namespace Content.Shared.Humanoid;
@@ -67,6 +71,100 @@ public sealed partial class HumanoidCharacterAppearance : IEquatable<HumanoidCha
 
         List<Color> outPalette = [newSkinColor, newHairColor, newEyeColor];
         return outPalette;
+    }
+
+    // hair and facial hair are handled different to other markings, so those get their own special treatment
+    private static List<Marking> PickHairsRandomMarking(HumanoidVisualLayers layer, MarkingsLimits layerLimits, IReadOnlyDictionary<string, MarkingPrototype> allMarkings, Color color)
+    {
+        var random = IoCManager.Resolve<IRobustRandom>();
+
+        if (allMarkings.Count == 0 || !random.Prob(layerLimits.Weight))
+            return [];
+
+        var hairId = PickWeightedMarkingId(allMarkings);
+        if (hairId is null || !allMarkings.TryGetValue(hairId, out var hairProto))
+            return [];
+
+        if (allMarkings.TryGetValue(hairProto.ID, out var hairMarking))
+            return [hairMarking.AsMarking().WithColor(color)];
+
+        var protoMan = IoCManager.Resolve<IPrototypeManager>();
+        var defaultHair = layer switch
+        {
+            HumanoidVisualLayers.FacialHair => HairStyles.DefaultFacialHairStyle,
+            _ => HairStyles.DefaultHairStyle,
+        };
+
+        var defaultHairProto = protoMan.Index(defaultHair);
+        return [new Marking(defaultHair, defaultHairProto.Sprites.Count).WithColor(color)];
+    }
+
+    private static List<Marking> PickLayerRandomMarkings(HumanoidVisualLayers layer, MarkingsLimits? layerLimits, IReadOnlyDictionary<string, MarkingPrototype> allMarkings, List<Color> palette)
+    {
+
+        if (layerLimits is null)
+            return [];
+
+        if (layer == HumanoidVisualLayers.Hair ||
+            layer == HumanoidVisualLayers.FacialHair)
+        {
+            return PickHairsRandomMarking(layer, layerLimits, allMarkings, palette[1]);
+        }
+
+        var random = IoCManager.Resolve<IRobustRandom>();
+        var layerWeight = layerLimits.Weight;
+        var pool = allMarkings.ToDictionary();
+
+        List<Marking> outMarkings = [];
+
+        for (var i = 0; i < layerLimits.Limit; i++)
+        {
+            // just in case there are somehow more points than markings
+            if (pool.Count == 0)
+                break;
+
+            // category roll to see if we add anything
+            if (!random.Prob(layerWeight))
+                continue;
+
+            var randomMarking = PickWeightedMarkingId(pool);
+
+            if (randomMarking is null || !pool.Remove(randomMarking, out var protoToAdd))
+                continue;
+
+            // select a random color from our two secondary colors.
+            // TODO: we may need some color validation here. unsure.
+            // TODO: multiple layers on a marking?
+            var color = random.Pick(palette.Skip(0).ToList());
+
+            outMarkings.Add(protoToAdd.AsMarking().WithColor(color));
+        }
+        return outMarkings;
+    }
+
+    private static string? PickWeightedMarkingId(IReadOnlyDictionary<string, MarkingPrototype> markings)
+    {
+        var random = IoCManager.Resolve<IRobustRandom>();
+
+        if (markings.Count == 0)
+            return null;
+
+        var sum = 0f;
+        foreach (var proto in markings.Values)
+            sum += Math.Max(0f, proto.RandomWeight);
+
+        if (sum <= 0f)
+            return random.Pick(markings.Keys.ToList());
+
+        var roll = random.NextFloat(sum);
+        foreach (var (id, proto) in markings)
+        {
+            roll -= Math.Max(0f, proto.RandomWeight);
+            if (roll <= 0f)
+                return id;
+        }
+
+        return markings.Last().Key;
     }
 
     #region Color Helpers

--- a/Content.Shared/_MACRO/Humanoid/HumanoidCharacterAppearance.Random.cs
+++ b/Content.Shared/_MACRO/Humanoid/HumanoidCharacterAppearance.Random.cs
@@ -1,0 +1,171 @@
+using System.Numerics;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Random;
+
+namespace Content.Shared.Humanoid;
+
+public sealed partial class HumanoidCharacterAppearance : IEquatable<HumanoidCharacterAppearance>
+{
+    /// <summary>
+    ///     Creates a new color palette from BaseColor.
+    ///     Uses integer provided to choose what kind of palette is generated.
+    /// </summary>
+    /// <param name="baseColor">The base color to generate a palette from.</param>
+    /// <param name="strategy">0 for split complimentary, 1 for triadic complimentary, any other value for a single compliment.</param>
+    /// <returns>A list of colours in the chosen palette.</returns>
+    /// <remarks>
+    ///     Personally I think this should be weighted, but I can't
+    ///     be bothered to implement that. -widgetbeck (and mq)
+    /// </remarks>
+    private static List<Color> GetPaletteFromBase(Color baseColor, int strategy)
+    {
+        return strategy switch
+        {
+            0 => GetSplitComplementaries(baseColor),
+            1 => GetTriadicComplementaries(baseColor),
+            _ => GetOneComplementary(baseColor),
+        };
+    }
+
+    /// <summary>
+    ///     Clamps a 3-toned color palette (skin, hair, eyes) to the desired ISkinColorationStrategy.
+    /// </summary>
+    /// <returns>
+    ///     A 3-toned color palette where:
+    ///     0 = Skin colour,
+    ///     1 = Hair colour,
+    ///     2 = Eye colour.
+    /// </returns>
+    private static List<Color> ClampPaletteToStrategy(List<Color> colorPalette, SkinColorationPrototype skinType)
+    {
+        var random = IoCManager.Resolve<IRobustRandom>();
+
+        // clamping from our generated colours instead of getting a random color.
+        var newSkinColor = skinType.Strategy.ClosestSkinColor(colorPalette[0]);
+
+        var newHairColor = colorPalette[1];
+        var newEyeColor = colorPalette[2];
+
+        if (skinType.RealisticColors)
+        {
+            // pick a random realistic hair color from the list and randomize it juuuuust a little bit.
+            newHairColor = random.Pick(HairStyles.RealisticHairColors);
+            newHairColor = newHairColor
+                .WithRed(RandomizeColor(newHairColor.R))
+                .WithGreen(RandomizeColor(newHairColor.G))
+                .WithBlue(RandomizeColor(newHairColor.B));
+
+            // and pick a random realistic eye color from the list.
+            newEyeColor = random.Pick(_realisticEyeColors);
+        }
+
+        if (skinType.SquashAllColors)
+        {
+            // crush the other colors down to valid skin colors.
+            newHairColor = skinType.Strategy.ClosestSkinColor(newHairColor);
+            newEyeColor = skinType.Strategy.ClosestSkinColor(newEyeColor);
+        }
+
+        List<Color> outPalette = [newSkinColor, newHairColor, newEyeColor];
+        return outPalette;
+    }
+
+    #region Color Helpers
+    // These are probably better off in Robust.Shared.Maths.Color. oh well
+
+    private static float RandomizeColor(float channel)
+    {
+        var random = IoCManager.Resolve<IRobustRandom>();
+        return MathHelper.Clamp01(channel + random.Next(-25, 25) / 100f);
+    }
+
+    /// <summary>
+    ///    Generates a complimentary colour palette for a provided
+    ///    colour by rotating a set amount of degrees around the
+    ///    colour wheel, and then varying the value and saturation
+    ///    slightly.
+    /// </summary>
+    /// <returns>
+    ///     A list of 3 colors.
+    /// </returns>
+    private static List<Color> GetComplementaryColors(Color color, double angle)
+    {
+        var random = IoCManager.Resolve<IRobustRandom>();
+        var hsl = Color.ToHsl(color);
+
+        // sorry about how messy these are, but to get all random values we need to reroll for positive and negative HSL.
+
+        var hVal = hsl.X + angle;
+        hVal = hVal >= 0.360 ? hVal - 0.360 : hVal;
+        var positiveHSL = new Vector4(
+            (float)hVal,
+            MathHelper.Clamp01(hsl.Y + random.Next(-20, 0) / 100f),
+            MathHelper.Clamp01(hsl.Z + random.Next(-15, 15) / 100f),
+            hsl.W);
+
+        var hVal1 = hsl.X - angle;
+        hVal1 = hVal1 <= 0 ? hVal1 + 0.360 : hVal1;
+        var negativeHSL = new Vector4(
+            (float)hVal1,
+            MathHelper.Clamp01(hsl.Y + random.Next(-20, 0) / 100f),
+            MathHelper.Clamp01(hsl.Z + random.Next(-15, 15) / 100f),
+            hsl.W);
+
+        var c0 = Color.FromHsl(positiveHSL);
+        var c1 = Color.FromHsl(negativeHSL);
+
+        var palette = new List<Color> { color, c0, c1 };
+        return palette;
+    }
+
+    /// <summary>
+    ///     Generates a list of triadic complementary colors
+    /// </summary>
+    private static List<Color> GetTriadicComplementaries(Color color)
+    {
+        return GetComplementaryColors(color, 0.120);
+    }
+
+    /// <summary>
+    ///     Generates a list of split complementary colors
+    /// </summary>
+    private static List<Color> GetSplitComplementaries(Color color)
+    {
+        return GetComplementaryColors(color, 0.150);
+    }
+
+    /// <summary>
+    ///     Generates a list containing the base color and two copies of a single complementary color
+    /// </summary>
+    private static List<Color> GetOneComplementary(Color color)
+    {
+        return GetComplementaryColors(color, 0.180);
+    }
+
+    /// <summary>
+    ///     Ensures that the provided colour is no lighter than the character's skin tone.
+    ///     Good for tattoos and similar markings.
+    /// </summary>
+    /// <param name="skinColor">Reference color</param>
+    /// <param name="toSquash">Colour that is being squashed</param>
+    /// <returns>
+    ///     A colour that is no lighter than the provided skin tone
+    /// </returns>
+    private static Color SquashToSkinLuminosity(Color skinColor, Color toSquash)
+    {
+        var skinColorHSL = Color.ToHsl(skinColor);
+        var toSquashHSL = Color.ToHsl(toSquash);
+
+        // check if the skin color is as dark as or darker than the marking color:
+        if (toSquashHSL.Z <= skinColorHSL.Z)
+        {
+            // if it is, don't fuck with it
+            return toSquash;
+        }
+
+        // otherwise, create a new color with the H, S, and A of toSquash, but the L of skinColor
+        var newColor = new Vector4(toSquashHSL.X, toSquashHSL.Y, skinColorHSL.Z, toSquashHSL.W);
+        return Color.FromHsl(newColor);
+    }
+    #endregion
+}

--- a/Content.Shared/_MACRO/Humanoid/HumanoidCharacterAppearance.Random.cs
+++ b/Content.Shared/_MACRO/Humanoid/HumanoidCharacterAppearance.Random.cs
@@ -7,7 +7,7 @@ using Robust.Shared.Random;
 
 namespace Content.Shared.Humanoid;
 
-public sealed partial class HumanoidCharacterAppearance : IEquatable<HumanoidCharacterAppearance>
+public sealed partial class HumanoidCharacterAppearance
 {
     /// <summary>
     ///     Creates a new color palette from BaseColor.
@@ -43,11 +43,20 @@ public sealed partial class HumanoidCharacterAppearance : IEquatable<HumanoidCha
     {
         var random = IoCManager.Resolve<IRobustRandom>();
 
-        // clamping from our generated colours instead of getting a random color.
-        var newSkinColor = skinType.Strategy.ClosestSkinColor(colorPalette[0]);
+        // this should never happen.
+        if (colorPalette.Count > 3)
+            return colorPalette;
 
-        var newHairColor = colorPalette[1];
-        var newEyeColor = colorPalette[2];
+        // theres gotta be a better way to do this
+        var newSkinColor = colorPalette.FirstOrDefault();
+        colorPalette.Remove(newSkinColor);
+        var newHairColor = colorPalette.FirstOrDefault();
+        colorPalette.Remove(newHairColor);
+        var newEyeColor = colorPalette.FirstOrDefault();
+        colorPalette.Remove(newEyeColor);
+
+        // clamping from our generated colours instead of getting a random color.
+        newSkinColor = skinType.Strategy.ClosestSkinColor(newSkinColor);
 
         if (skinType.RealisticColors)
         {
@@ -79,11 +88,11 @@ public sealed partial class HumanoidCharacterAppearance : IEquatable<HumanoidCha
         var random = IoCManager.Resolve<IRobustRandom>();
 
         if (allMarkings.Count == 0 || !random.Prob(layerLimits.Weight))
-            return [];
+            return new();
 
         var hairId = PickWeightedMarkingId(allMarkings);
         if (hairId is null || !allMarkings.TryGetValue(hairId, out var hairProto))
-            return [];
+            return new();
 
         if (allMarkings.TryGetValue(hairProto.ID, out var hairMarking))
             return [hairMarking.AsMarking().WithColor(color)];
@@ -103,7 +112,7 @@ public sealed partial class HumanoidCharacterAppearance : IEquatable<HumanoidCha
     {
 
         if (layerLimits is null)
-            return [];
+            return new();
 
         if (layer == HumanoidVisualLayers.Hair ||
             layer == HumanoidVisualLayers.FacialHair)
@@ -115,7 +124,7 @@ public sealed partial class HumanoidCharacterAppearance : IEquatable<HumanoidCha
         var layerWeight = layerLimits.Weight;
         var pool = allMarkings.ToDictionary();
 
-        List<Marking> outMarkings = [];
+        List<Marking> outMarkings = new();
 
         for (var i = 0; i < layerLimits.Limit; i++)
         {
@@ -185,7 +194,7 @@ public sealed partial class HumanoidCharacterAppearance : IEquatable<HumanoidCha
     /// <returns>
     ///     A list of 3 colors.
     /// </returns>
-    private static List<Color> GetComplementaryColors(Color color, double angle)
+    private static List<Color> GetComplementaryColors(Color color, float angle)
     {
         var random = IoCManager.Resolve<IRobustRandom>();
         var hsl = Color.ToHsl(color);
@@ -194,19 +203,19 @@ public sealed partial class HumanoidCharacterAppearance : IEquatable<HumanoidCha
         // since we want to rotate x degrees around the colour wheel, we need to do so in both directions- doing x + x degrees will give us the wrong hue!
 
         var hVal = hsl.X + angle;
-        hVal = hVal >= 0.360 ? hVal - 0.360 : hVal;
+        hVal -= MathF.Floor(hVal);
         var positiveHSL = new Vector4(
-            (float)hVal,
+            hVal,
             MathHelper.Clamp01(hsl.Y + random.Next(-20, 0) / 100f),
-            MathHelper.Clamp01(hsl.Z + random.Next(-15, 15) / 100f),
+            MathHelper.Clamp01(hsl.Z + random.Next(-15, 16) / 100f),
             hsl.W);
 
         var hVal1 = hsl.X - angle;
-        hVal1 = hVal1 <= 0 ? hVal1 + 0.360 : hVal1;
+        hVal1 += hVal1 <= 0f ? hVal1 + 0.360f : hVal1;
         var negativeHSL = new Vector4(
-            (float)hVal1,
+            hVal1,
             MathHelper.Clamp01(hsl.Y + random.Next(-20, 0) / 100f),
-            MathHelper.Clamp01(hsl.Z + random.Next(-15, 15) / 100f),
+            MathHelper.Clamp01(hsl.Z + random.Next(-15, 16) / 100f),
             hsl.W);
 
         var c0 = Color.FromHsl(positiveHSL);
@@ -221,7 +230,7 @@ public sealed partial class HumanoidCharacterAppearance : IEquatable<HumanoidCha
     /// </summary>
     private static List<Color> GetTriadicComplementaries(Color color)
     {
-        return GetComplementaryColors(color, 0.120);
+        return GetComplementaryColors(color, 0.120f);
     }
 
     /// <summary>
@@ -229,7 +238,7 @@ public sealed partial class HumanoidCharacterAppearance : IEquatable<HumanoidCha
     /// </summary>
     private static List<Color> GetSplitComplementaries(Color color)
     {
-        return GetComplementaryColors(color, 0.150);
+        return GetComplementaryColors(color, 0.150f);
     }
 
     /// <summary>
@@ -237,7 +246,7 @@ public sealed partial class HumanoidCharacterAppearance : IEquatable<HumanoidCha
     /// </summary>
     private static List<Color> GetOneComplementary(Color color)
     {
-        return GetComplementaryColors(color, 0.180);
+        return GetComplementaryColors(color, 0.180f);
     }
 
     /// <summary>

--- a/Content.Shared/_MACRO/Humanoid/HumanoidCharacterAppearance.Random.cs
+++ b/Content.Shared/_MACRO/Humanoid/HumanoidCharacterAppearance.Random.cs
@@ -1,14 +1,20 @@
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Numerics;
 using Content.Shared.Humanoid.Markings;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
+using Robust.Shared.Utility;
+using Content.Shared.Humanoid.Markings.ColoringTypes;
+
 
 namespace Content.Shared.Humanoid;
 
 public sealed partial class HumanoidCharacterAppearance
 {
+    private readonly static string SkinColorKey = "skinColor";
+    private readonly static string HairColorKey = "hairColor";
+    private readonly static string EyeColorKey = "eyeColor";
+
     /// <summary>
     ///     Creates a new color palette from BaseColor.
     ///     Uses integer provided to choose what kind of palette is generated.
@@ -40,13 +46,9 @@ public sealed partial class HumanoidCharacterAppearance
     ///     2 = Eye colour.
     /// </returns>
     /// <remarks>TODO: might be better to make this return a dictionary or enum.</remarks>
-    private static List<Color> ClampPaletteToStrategy(List<Color> colorPalette, SkinColorationPrototype skinType)
+    private static Dictionary<string, Color> ClampPaletteToStrategy(List<Color> colorPalette, SkinColorationPrototype skinType)
     {
         var random = IoCManager.Resolve<IRobustRandom>();
-
-        // this should never happen.
-        if (colorPalette.Count > 3)
-            return colorPalette;
 
         // theres gotta be a better way to do this
         var newSkinColor = colorPalette.FirstOrDefault();
@@ -78,7 +80,12 @@ public sealed partial class HumanoidCharacterAppearance
             newEyeColor = skinType.Strategy.ClosestSkinColor(newEyeColor);
         }
 
-        return new List<Color> { newSkinColor, newHairColor, newEyeColor };
+        return new Dictionary<string, Color>
+        {
+            { SkinColorKey, newSkinColor },
+            { HairColorKey, newHairColor },
+            { EyeColorKey, newEyeColor }
+        };
     }
 
     /// <summary>
@@ -118,7 +125,7 @@ public sealed partial class HumanoidCharacterAppearance
     /// <param name="allMarkings">A list of all markings for the layer.</param>
     /// <param name="palette">A list of colors to choose from for the markings.</param>
     /// <returns>A list of markings for the desired layer.</returns>
-    private static List<Marking> PickLayerRandomMarkings(HumanoidVisualLayers layer, MarkingsLimits? layerLimits, IReadOnlyDictionary<string, MarkingPrototype> allMarkings, List<Color> palette)
+    private static List<Marking> PickLayerRandomMarkings(HumanoidVisualLayers layer, MarkingsLimits? layerLimits, IReadOnlyDictionary<string, MarkingPrototype> allMarkings, Dictionary<string, Color> palette)
     {
 
         if (layerLimits is null)
@@ -127,7 +134,7 @@ public sealed partial class HumanoidCharacterAppearance
         if (layer == HumanoidVisualLayers.Hair ||
             layer == HumanoidVisualLayers.FacialHair)
         {
-            return PickHairsRandomMarking(layer, layerLimits, allMarkings, palette[1]);
+            return PickHairsRandomMarking(layer, layerLimits, allMarkings, palette.GetValueOrDefault(HairColorKey));
         }
 
         var random = IoCManager.Resolve<IRobustRandom>();
@@ -151,12 +158,18 @@ public sealed partial class HumanoidCharacterAppearance
             if (randomMarking is null || !pool.Remove(randomMarking, out var protoToAdd))
                 continue;
 
-            // select a random color from our two secondary colors.
-            // TODO: we may need some color validation here. unsure.
-            // TODO: multiple layers on a marking?
-            var color = random.Pick(palette.ToList());
+            // OPTION 1: upstream coloring
+            //var colors = MarkingColoring.GetMarkingLayerColors(protoToAdd, palette.GetValueOrDefault(SkinColorKey), palette.GetValueOrDefault(EyeColorKey), outMarkings);
 
-            outMarkings.Add(protoToAdd.AsMarking().WithColor(color));
+            // OPTION 2: random coloring
+            List<Color> colors = new();
+            palette.Remove(SkinColorKey);
+            foreach (var sprite in protoToAdd.Sprites)
+            {
+                colors.Add(random.Pick(palette.Values));
+            }
+
+            outMarkings.Add(new Marking(protoToAdd, colors));
         }
         return outMarkings;
     }

--- a/Content.Shared/_MACRO/Humanoid/HumanoidCharacterAppearance.Random.cs
+++ b/Content.Shared/_MACRO/Humanoid/HumanoidCharacterAppearance.Random.cs
@@ -187,7 +187,10 @@ public sealed partial class HumanoidCharacterAppearance
                     protoToAdd.Coloring.Layers is not { } layers ||
                     !layers.TryGetValue(name, out var layerColoring))
                 {
-                    colors.Add(Color.White);
+                    colors.Add(protoToAdd.Coloring.Default.GetColor(
+                        palette.GetValueOrDefault(SkinColorKey),
+                        palette.GetValueOrDefault(EyeColorKey),
+                        outMarkings));
                     continue;
                 }
 

--- a/Content.Shared/_MACRO/Humanoid/HumanoidCharacterAppearance.Random.cs
+++ b/Content.Shared/_MACRO/Humanoid/HumanoidCharacterAppearance.Random.cs
@@ -39,6 +39,7 @@ public sealed partial class HumanoidCharacterAppearance
     ///     1 = Hair colour,
     ///     2 = Eye colour.
     /// </returns>
+    /// <remarks>TODO: might be better to make this return a dictionary or enum.</remarks>
     private static List<Color> ClampPaletteToStrategy(List<Color> colorPalette, SkinColorationPrototype skinType)
     {
         var random = IoCManager.Resolve<IRobustRandom>();
@@ -55,7 +56,6 @@ public sealed partial class HumanoidCharacterAppearance
         var newEyeColor = colorPalette.FirstOrDefault();
         colorPalette.Remove(newEyeColor);
 
-        // clamping from our generated colours instead of getting a random color.
         newSkinColor = skinType.Strategy.ClosestSkinColor(newSkinColor);
 
         if (skinType.RealisticColors)
@@ -78,11 +78,14 @@ public sealed partial class HumanoidCharacterAppearance
             newEyeColor = skinType.Strategy.ClosestSkinColor(newEyeColor);
         }
 
-        List<Color> outPalette = [newSkinColor, newHairColor, newEyeColor];
-        return outPalette;
+        return new List<Color> { newSkinColor, newHairColor, newEyeColor };
     }
 
-    // hair and facial hair are handled different to other markings, so those get their own special treatment
+    /// <summary>
+    ///     Picks a random marking for a <see cref="HumanoidVisualLayers.Hair"/> or <see cref="HumanoidVisualLayers.FacialHair"/> layer.
+    ///     These layers are handled differently to other markings, so we need unique behaviour for them.
+    /// </summary>
+    /// <returns>A list of markings for the <see cref="HumanoidVisualLayers"/>.</returns>
     private static List<Marking> PickHairsRandomMarking(HumanoidVisualLayers layer, MarkingsLimits layerLimits, IReadOnlyDictionary<string, MarkingPrototype> allMarkings, Color color)
     {
         var random = IoCManager.Resolve<IRobustRandom>();
@@ -95,7 +98,7 @@ public sealed partial class HumanoidCharacterAppearance
             return new();
 
         if (allMarkings.TryGetValue(hairProto.ID, out var hairMarking))
-            return [hairMarking.AsMarking().WithColor(color)];
+            return new List<Marking> { hairMarking.AsMarking().WithColor(color) };
 
         var protoMan = IoCManager.Resolve<IPrototypeManager>();
         var defaultHair = layer switch
@@ -105,9 +108,16 @@ public sealed partial class HumanoidCharacterAppearance
         };
 
         var defaultHairProto = protoMan.Index(defaultHair);
-        return [new Marking(defaultHair, defaultHairProto.Sprites.Count).WithColor(color)];
+        return new List<Marking> { new Marking(defaultHair, defaultHairProto.Sprites.Count).WithColor(color) };
     }
 
+    /// <summary>
+    ///     Generates a list of random coloured markings for a <see cref="HumanoidVisualLayers"/> layer,
+    ///     with respect to the layer and marking weights and marking limits.
+    /// </summary>
+    /// <param name="allMarkings">A list of all markings for the layer.</param>
+    /// <param name="palette">A list of colors to choose from for the markings.</param>
+    /// <returns>A list of markings for the desired layer.</returns>
     private static List<Marking> PickLayerRandomMarkings(HumanoidVisualLayers layer, MarkingsLimits? layerLimits, IReadOnlyDictionary<string, MarkingPrototype> allMarkings, List<Color> palette)
     {
 
@@ -144,13 +154,17 @@ public sealed partial class HumanoidCharacterAppearance
             // select a random color from our two secondary colors.
             // TODO: we may need some color validation here. unsure.
             // TODO: multiple layers on a marking?
-            var color = random.Pick(palette.Skip(0).ToList());
+            var color = random.Pick(palette.ToList());
 
             outMarkings.Add(protoToAdd.AsMarking().WithColor(color));
         }
         return outMarkings;
     }
 
+    /// <summary>
+    ///     Uses <see cref="MarkingPrototype"/> weights to pick a random marking from a provided dictionary.
+    /// </summary>
+    /// <returns>The string ID of the chosen <see cref="MarkingPrototype"/>.</returns>
     private static string? PickWeightedMarkingId(IReadOnlyDictionary<string, MarkingPrototype> markings)
     {
         var random = IoCManager.Resolve<IRobustRandom>();

--- a/Content.Shared/_MACRO/Humanoid/HumanoidCharacterAppearance.Random.cs
+++ b/Content.Shared/_MACRO/Humanoid/HumanoidCharacterAppearance.Random.cs
@@ -162,11 +162,41 @@ public sealed partial class HumanoidCharacterAppearance
             //var colors = MarkingColoring.GetMarkingLayerColors(protoToAdd, palette.GetValueOrDefault(SkinColorKey), palette.GetValueOrDefault(EyeColorKey), outMarkings);
 
             // OPTION 2: random coloring
+            // List<Color> colors = new();
+            // palette.Remove(SkinColorKey);
+            // foreach (var sprite in protoToAdd.Sprites)
+            // {
+            //     colors.Add(random.Pick(palette.Values));
+            // }
+
+            // OPTION 3: what if the joker could beatbox
             List<Color> colors = new();
-            palette.Remove(SkinColorKey);
-            foreach (var sprite in protoToAdd.Sprites)
+            for (var j = 0; j < protoToAdd.Sprites.Count; j++)
             {
-                colors.Add(random.Pick(palette.Values));
+                // code here is from MarkingColoring.GetMarkingLayerColors
+                // who give a fuuuuuuuuu
+                // Getting layer name
+                string? name = protoToAdd.Sprites[j] switch
+                {
+                    SpriteSpecifier.Rsi rsi => rsi.RsiState,
+                    SpriteSpecifier.Texture texture => texture.TexturePath.Filename,
+                    _ => null
+                };
+
+                if (name == null ||
+                    protoToAdd.Coloring.Layers is not { } layers ||
+                    !layers.TryGetValue(name, out var layerColoring))
+                {
+                    colors.Add(Color.White);
+                    continue;
+                }
+
+                // and here is where i would put my layer rules
+                // IF THEY WERE SERIALIZABLE
+                colors.Add(layerColoring.GetColor(
+                    palette.GetValueOrDefault(SkinColorKey),
+                    palette.GetValueOrDefault(EyeColorKey),
+                    outMarkings));
             }
 
             outMarkings.Add(new Marking(protoToAdd, colors));

--- a/Resources/Locale/en-US/_MACRO/preferences/ui/humanoid-profile-editor.ftl
+++ b/Resources/Locale/en-US/_MACRO/preferences/ui/humanoid-profile-editor.ftl
@@ -1,0 +1,1 @@
+humanoid-profile-editor-randomize-appearance-button = Randomize appearance

--- a/Resources/Prototypes/Body/Species/human.yml
+++ b/Resources/Prototypes/Body/Species/human.yml
@@ -5,6 +5,7 @@
     enum.HumanoidVisualLayers.Hair:
       limit: 1
       required: false
+      weight: 1 # MACRO
     enum.HumanoidVisualLayers.FacialHair:
       limit: 1
       required: false

--- a/Resources/Prototypes/Body/Species/slime.yml
+++ b/Resources/Prototypes/Body/Species/slime.yml
@@ -5,6 +5,7 @@
     enum.HumanoidVisualLayers.Hair:
       limit: 1
       required: false
+      weight: 1 # MACRO
     enum.HumanoidVisualLayers.FacialHair:
       limit: 1
       required: false

--- a/Resources/Prototypes/Body/Species/vox.yml
+++ b/Resources/Prototypes/Body/Species/vox.yml
@@ -6,6 +6,7 @@
       limit: 1
       onlyGroupWhitelisted: true
       required: false
+      weight: 1 # MACRO
     enum.HumanoidVisualLayers.FacialHair:
       limit: 1
       onlyGroupWhitelisted: true

--- a/Resources/Prototypes/Entities/Mobs/Customization/Markings/Vulpkanin/vulpkanin_limbs.yml
+++ b/Resources/Prototypes/Entities/Mobs/Customization/Markings/Vulpkanin/vulpkanin_limbs.yml
@@ -8,8 +8,8 @@
   coloring:
     default:
       type:
-        !type:SimpleColoring
-          color: "#e5e3d1"
+        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
+          # color: "#e5e3d1"
 
 - type: marking
   id: VulpClawsHandRight
@@ -21,8 +21,8 @@
   coloring:
     default:
       type:
-        !type:SimpleColoring
-          color: "#e5e3d1"
+        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
+          # color: "#e5e3d1"
 
 - type: marking
   id: VulpClawsFootLeft
@@ -34,8 +34,8 @@
   coloring:
     default:
       type:
-        !type:SimpleColoring
-          color: "#e5e3d1"
+        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
+          # color: "#e5e3d1"
 
 - type: marking
   id: VulpClawsFootRight
@@ -47,8 +47,8 @@
   coloring:
     default:
       type:
-        !type:SimpleColoring
-          color: "#e5e3d1"
+        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
+          # color: "#e5e3d1"
 
 # Crest
 
@@ -63,8 +63,8 @@
   coloring:
     default:
       type:
-        !type:SimpleColoring
-          color: "#e5e3d1"
+        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
+          # color: "#e5e3d1"
 
 - type: marking
   id: VulpPointsCrestArmLeft
@@ -76,8 +76,8 @@
   coloring:
     default:
       type:
-        !type:SimpleColoring
-          color: "#e5e3d1"
+        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
+          # color: "#e5e3d1"
 
 - type: marking
   id: VulpPointsCrestFootLeft
@@ -89,8 +89,8 @@
   coloring:
     default:
       type:
-        !type:SimpleColoring
-          color: "#e5e3d1"
+        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
+          # color: "#e5e3d1"
 
 - type: marking
   id: VulpPointsCrestHandLeft
@@ -102,8 +102,8 @@
   coloring:
     default:
       type:
-        !type:SimpleColoring
-          color: "#e5e3d1"
+        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
+          # color: "#e5e3d1"
 
 ## Right Side
 
@@ -117,8 +117,8 @@
   coloring:
     default:
       type:
-        !type:SimpleColoring
-          color: "#e5e3d1"
+        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
+          # color: "#e5e3d1"
 
 - type: marking
   id: VulpPointsCrestArmRight
@@ -130,8 +130,8 @@
   coloring:
     default:
       type:
-        !type:SimpleColoring
-          color: "#e5e3d1"
+        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
+          # color: "#e5e3d1"
 
 - type: marking
   id: VulpPointsCrestFootRight
@@ -143,8 +143,8 @@
   coloring:
     default:
       type:
-        !type:SimpleColoring
-          color: "#e5e3d1"
+        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
+          # color: "#e5e3d1"
 
 - type: marking
   id: VulpPointsCrestHandRight
@@ -156,12 +156,12 @@
   coloring:
     default:
       type:
-        !type:SimpleColoring
-          color: "#e5e3d1"
+        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
+          # color: "#e5e3d1"
 
 # Fade
 
-## Left Side 
+## Left Side
 
 - type: marking
   id: VulpPointsFadeLegLeft
@@ -173,8 +173,8 @@
   coloring:
     default:
       type:
-        !type:SimpleColoring
-          color: "#e5e3d1"
+        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
+          # color: "#e5e3d1"
 
 - type: marking
   id: VulpPointsFadeArmLeft
@@ -186,8 +186,8 @@
   coloring:
     default:
       type:
-        !type:SimpleColoring
-          color: "#e5e3d1"
+        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
+          # color: "#e5e3d1"
 
 - type: marking
   id: VulpPointsFadeFootLeft
@@ -199,8 +199,8 @@
   coloring:
     default:
       type:
-        !type:SimpleColoring
-          color: "#e5e3d1"
+        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
+          # color: "#e5e3d1"
 
 - type: marking
   id: VulpPointsFadeHandLeft
@@ -212,8 +212,8 @@
   coloring:
     default:
       type:
-        !type:SimpleColoring
-          color: "#e5e3d1"
+        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
+          # color: "#e5e3d1"
 
 ## Right Side
 
@@ -227,8 +227,8 @@
   coloring:
     default:
       type:
-        !type:SimpleColoring
-          color: "#e5e3d1"
+        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
+          # color: "#e5e3d1"
 
 - type: marking
   id: VulpPointsFadeArmRight
@@ -240,8 +240,8 @@
   coloring:
     default:
       type:
-        !type:SimpleColoring
-          color: "#e5e3d1"
+        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
+          # color: "#e5e3d1"
 
 - type: marking
   id: VulpPointsFadeFootRight
@@ -253,8 +253,8 @@
   coloring:
     default:
       type:
-        !type:SimpleColoring
-          color: "#e5e3d1"
+        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
+          # color: "#e5e3d1"
 
 - type: marking
   id: VulpPointsFadeHandRight
@@ -266,8 +266,8 @@
   coloring:
     default:
       type:
-        !type:SimpleColoring
-          color: "#e5e3d1"
+        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
+          # color: "#e5e3d1"
 
 # Sharp
 
@@ -283,8 +283,8 @@
   coloring:
     default:
       type:
-        !type:SimpleColoring
-          color: "#e5e3d1"
+        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
+          # color: "#e5e3d1"
 
 - type: marking
   id: VulpPointsSharpArmLeft
@@ -296,8 +296,8 @@
   coloring:
     default:
       type:
-        !type:SimpleColoring
-          color: "#e5e3d1"
+        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
+          # color: "#e5e3d1"
 
 - type: marking
   id: VulpPointsSharpLongArmLeft
@@ -309,8 +309,8 @@
   coloring:
     default:
       type:
-        !type:SimpleColoring
-          color: "#e5e3d1"
+        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
+          # color: "#e5e3d1"
 
 - type: marking
   id: VulpPointsSharpFootLeft
@@ -322,8 +322,8 @@
   coloring:
     default:
       type:
-        !type:SimpleColoring
-          color: "#e5e3d1"
+        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
+          # color: "#e5e3d1"
 
 - type: marking
   id: VulpPointsSharpHandLeft
@@ -335,8 +335,8 @@
   coloring:
     default:
       type:
-        !type:SimpleColoring
-          color: "#e5e3d1"
+        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
+          # color: "#e5e3d1"
 
 ## Right Side
 
@@ -350,8 +350,8 @@
   coloring:
     default:
       type:
-        !type:SimpleColoring
-          color: "#e5e3d1"
+        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
+          # color: "#e5e3d1"
 
 - type: marking
   id: VulpPointsSharpArmRight
@@ -363,8 +363,8 @@
   coloring:
     default:
       type:
-        !type:SimpleColoring
-          color: "#e5e3d1"
+        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
+          # color: "#e5e3d1"
 
 - type: marking
   id: VulpPointsSharpLongArmRight
@@ -376,8 +376,8 @@
   coloring:
     default:
       type:
-        !type:SimpleColoring
-          color: "#e5e3d1"
+        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
+          # color: "#e5e3d1"
 
 - type: marking
   id: VulpPointsSharpFootRight
@@ -389,8 +389,8 @@
   coloring:
     default:
       type:
-        !type:SimpleColoring
-          color: "#e5e3d1"
+        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
+          # color: "#e5e3d1"
 
 - type: marking
   id: VulpPointsSharpHandRight
@@ -402,5 +402,5 @@
   coloring:
     default:
       type:
-        !type:SimpleColoring
-          color: "#e5e3d1"
+        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
+          # color: "#e5e3d1"

--- a/Resources/Prototypes/Entities/Mobs/Customization/Markings/Vulpkanin/vulpkanin_snout.yml
+++ b/Resources/Prototypes/Entities/Mobs/Customization/Markings/Vulpkanin/vulpkanin_snout.yml
@@ -7,6 +7,10 @@
   sprites:
     - sprite: Mobs/Customization/Vulpkanin/snout_markings.rsi
       state: snout
+  coloring: # MACRO add
+    default:
+      type:
+        !type:SkinColoring
 
 - type: marking
   id: VulpSnoutNose

--- a/Resources/Prototypes/Entities/Mobs/Customization/Markings/arachnid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Customization/Markings/arachnid.yml
@@ -6,6 +6,11 @@
   sprites:
   - sprite: Mobs/Customization/Arachnid/chelicerae.rsi
     state: downwards
+    coloring: # MACRO add
+    default:
+      type:
+        !type:SkinColoring
+
 
 - type: marking
   id: ArachnidCheliceraeInwards
@@ -14,6 +19,10 @@
   sprites:
   - sprite: Mobs/Customization/Arachnid/chelicerae.rsi
     state: inwards
+    coloring: # MACRO add
+    default:
+      type:
+        !type:SkinColoring
 
 # Appendages
 - type: marking

--- a/Resources/Prototypes/Entities/Mobs/Customization/Markings/diona.yml
+++ b/Resources/Prototypes/Entities/Mobs/Customization/Markings/diona.yml
@@ -5,8 +5,8 @@
   coloring:
     default:
       type:
-        !type:SimpleColoring
-          color: "#FFFFFF"
+        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
+          # color: "#FFFFFF"
   sprites:
   - sprite: Mobs/Customization/diona.rsi
     state: thorns_head
@@ -18,8 +18,8 @@
   coloring:
     default:
       type:
-        !type:SimpleColoring
-          color: "#FFFFFF"
+        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
+          # color: "#FFFFFF"
   sprites:
   - sprite: Mobs/Customization/diona.rsi
     state: thorns_body
@@ -31,8 +31,8 @@
   coloring:
     default:
       type:
-        !type:SimpleColoring
-          color: "#FFFFFF"
+        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
+          # color: "#FFFFFF"
   sprites:
   - sprite: Mobs/Customization/diona.rsi
     state: flowers_head
@@ -44,8 +44,8 @@
   coloring:
     default:
       type:
-        !type:SimpleColoring
-          color: "#FFFFFF"
+        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
+          # color: "#FFFFFF"
   sprites:
   - sprite: Mobs/Customization/diona.rsi
     state: flowers_body
@@ -69,8 +69,8 @@
   coloring:
     default:
       type:
-        !type:SimpleColoring
-          color: "#FFFFFF"
+        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
+          # color: "#FFFFFF"
   sprites:
   - sprite: Mobs/Customization/diona.rsi
     state: bloom
@@ -82,8 +82,8 @@
   coloring:
     default:
       type:
-        !type:SimpleColoring
-          color: "#FFFFFF"
+        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
+          # color: "#FFFFFF"
   sprites:
   - sprite: Mobs/Customization/diona.rsi
     state: bracket
@@ -107,8 +107,8 @@
   coloring:
     default:
       type:
-        !type:SimpleColoring
-          color: "#FFFFFF"
+        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
+          # color: "#FFFFFF"
   sprites:
   - sprite: Mobs/Customization/diona.rsi
     state: cornflower
@@ -120,8 +120,8 @@
   coloring:
     default:
       type:
-        !type:SimpleColoring
-          color: "#FFFFFF"
+        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
+          # color: "#FFFFFF"
   sprites:
   - sprite: Mobs/Customization/diona.rsi
     state: ficus
@@ -133,8 +133,8 @@
   coloring:
     default:
       type:
-        !type:SimpleColoring
-          color: "#FFFFFF"
+        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
+          # color: "#FFFFFF"
   sprites:
   - sprite: Mobs/Customization/diona.rsi
     state: garland
@@ -146,8 +146,8 @@
   coloring:
     default:
       type:
-        !type:SimpleColoring
-          color: "#FFFFFF"
+        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
+          # color: "#FFFFFF"
   sprites:
   - sprite: Mobs/Customization/diona.rsi
     state: king
@@ -159,8 +159,8 @@
   coloring:
     default:
       type:
-        !type:SimpleColoring
-          color: "#FFFFFF"
+        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
+          # color: "#FFFFFF"
   sprites:
   - sprite: Mobs/Customization/diona.rsi
     state: laurel
@@ -172,8 +172,8 @@
   coloring:
     default:
       type:
-        !type:SimpleColoring
-          color: "#FFFFFF"
+        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
+          # color: "#FFFFFF"
   sprites:
   - sprite: Mobs/Customization/diona.rsi
     state: leafy
@@ -185,8 +185,8 @@
   coloring:
     default:
       type:
-        !type:SimpleColoring
-          color: "#FFFFFF"
+        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
+          # color: "#FFFFFF"
   sprites:
   - sprite: Mobs/Customization/diona.rsi
     state: lotus
@@ -198,8 +198,8 @@
   coloring:
     default:
       type:
-        !type:SimpleColoring
-          color: "#FFFFFF"
+        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
+          # color: "#FFFFFF"
   sprites:
   - sprite: Mobs/Customization/diona.rsi
     state: meadow
@@ -211,8 +211,8 @@
   coloring:
     default:
       type:
-        !type:SimpleColoring
-          color: "#FFFFFF"
+        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
+          # color: "#FFFFFF"
   sprites:
   - sprite: Mobs/Customization/diona.rsi
     state: oak
@@ -224,8 +224,8 @@
   coloring:
     default:
       type:
-        !type:SimpleColoring
-          color: "#FFFFFF"
+        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
+          # color: "#FFFFFF"
   sprites:
   - sprite: Mobs/Customization/diona.rsi
     state: palm
@@ -237,8 +237,8 @@
   coloring:
     default:
       type:
-        !type:SimpleColoring
-          color: "#FFFFFF"
+        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
+          # color: "#FFFFFF"
   sprites:
   - sprite: Mobs/Customization/diona.rsi
     state: root
@@ -250,8 +250,8 @@
   coloring:
     default:
       type:
-        !type:SimpleColoring
-          color: "#FFFFFF"
+        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
+          # color: "#FFFFFF"
   sprites:
   - sprite: Mobs/Customization/diona.rsi
     state: rose
@@ -263,8 +263,8 @@
   coloring:
     default:
       type:
-        !type:SimpleColoring
-          color: "#FFFFFF"
+        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
+          # color: "#FFFFFF"
   sprites:
   - sprite: Mobs/Customization/diona.rsi
     state: rosey
@@ -276,8 +276,8 @@
   coloring:
     default:
       type:
-        !type:SimpleColoring
-          color: "#FFFFFF"
+        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
+          # color: "#FFFFFF"
   sprites:
   - sprite: Mobs/Customization/diona.rsi
     state: shrub
@@ -289,8 +289,8 @@
   coloring:
     default:
       type:
-        !type:SimpleColoring
-          color: "#FFFFFF"
+        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
+          # color: "#FFFFFF"
   sprites:
   - sprite: Mobs/Customization/diona.rsi
     state: spinner
@@ -302,8 +302,8 @@
   coloring:
     default:
       type:
-        !type:SimpleColoring
-          color: "#FFFFFF"
+        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
+          # color: "#FFFFFF"
   sprites:
   - sprite: Mobs/Customization/diona.rsi
     state: sprout
@@ -315,8 +315,8 @@
   coloring:
     default:
       type:
-        !type:SimpleColoring
-          color: "#FFFFFF"
+        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
+          # color: "#FFFFFF"
   sprites:
   - sprite: Mobs/Customization/diona.rsi
     state: vine
@@ -328,8 +328,8 @@
   coloring:
     default:
       type:
-        !type:SimpleColoring
-          color: "#FFFFFF"
+        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
+          # color: "#FFFFFF"
   sprites:
   - sprite: Mobs/Customization/diona.rsi
     state: vinel
@@ -341,8 +341,8 @@
   coloring:
     default:
       type:
-        !type:SimpleColoring
-          color: "#FFFFFF"
+        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
+          # color: "#FFFFFF"
   sprites:
   - sprite: Mobs/Customization/diona.rsi
     state: vines
@@ -354,8 +354,8 @@
   coloring:
     default:
       type:
-        !type:SimpleColoring
-          color: "#FFFFFF"
+        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
+          #color: "#FFFFFF"
   sprites:
   - sprite: Mobs/Customization/diona.rsi
     state: wildflower

--- a/Resources/Prototypes/Entities/Mobs/Customization/Markings/diona.yml
+++ b/Resources/Prototypes/Entities/Mobs/Customization/Markings/diona.yml
@@ -2,11 +2,11 @@
   id: DionaThornsHead
   bodyPart: Head
   groupWhitelist: [Diona]
-  coloring:
-    default:
-      type:
-        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
-          # color: "#FFFFFF"
+  # coloring: # MACRO remove
+  #   default:
+  #     type:
+  #       !type:SimpleColoring
+  #         color: "#FFFFFF"
   sprites:
   - sprite: Mobs/Customization/diona.rsi
     state: thorns_head
@@ -15,11 +15,11 @@
   id: DionaThornsBody
   bodyPart: Chest
   groupWhitelist: [Diona]
-  coloring:
-    default:
-      type:
-        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
-          # color: "#FFFFFF"
+  # coloring: # MACRO remove
+  #   default:
+  #     type:
+  #       !type:SimpleColoring
+  #         color: "#FFFFFF"
   sprites:
   - sprite: Mobs/Customization/diona.rsi
     state: thorns_body
@@ -31,8 +31,8 @@
   coloring:
     default:
       type:
-        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
-          # color: "#FFFFFF"
+        !type:SimpleColoring
+          color: "#FFFFFF"
   sprites:
   - sprite: Mobs/Customization/diona.rsi
     state: flowers_head
@@ -44,8 +44,8 @@
   coloring:
     default:
       type:
-        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
-          # color: "#FFFFFF"
+        !type:SimpleColoring
+          color: "#FFFFFF"
   sprites:
   - sprite: Mobs/Customization/diona.rsi
     state: flowers_body
@@ -69,8 +69,8 @@
   coloring:
     default:
       type:
-        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
-          # color: "#FFFFFF"
+        !type:SimpleColoring
+          color: "#FFFFFF"
   sprites:
   - sprite: Mobs/Customization/diona.rsi
     state: bloom
@@ -82,8 +82,8 @@
   coloring:
     default:
       type:
-        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
-          # color: "#FFFFFF"
+        !type:SimpleColoring
+          color: "#FFFFFF"
   sprites:
   - sprite: Mobs/Customization/diona.rsi
     state: bracket
@@ -107,8 +107,8 @@
   coloring:
     default:
       type:
-        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
-          # color: "#FFFFFF"
+        !type:SimpleColoring
+          color: "#FFFFFF"
   sprites:
   - sprite: Mobs/Customization/diona.rsi
     state: cornflower
@@ -120,8 +120,8 @@
   coloring:
     default:
       type:
-        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
-          # color: "#FFFFFF"
+        !type:SimpleColoring
+          color: "#FFFFFF"
   sprites:
   - sprite: Mobs/Customization/diona.rsi
     state: ficus
@@ -133,8 +133,8 @@
   coloring:
     default:
       type:
-        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
-          # color: "#FFFFFF"
+        !type:SimpleColoring
+          color: "#FFFFFF"
   sprites:
   - sprite: Mobs/Customization/diona.rsi
     state: garland
@@ -146,8 +146,8 @@
   coloring:
     default:
       type:
-        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
-          # color: "#FFFFFF"
+        !type:SimpleColoring
+          color: "#FFFFFF"
   sprites:
   - sprite: Mobs/Customization/diona.rsi
     state: king
@@ -159,8 +159,8 @@
   coloring:
     default:
       type:
-        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
-          # color: "#FFFFFF"
+        !type:SimpleColoring
+          color: "#FFFFFF"
   sprites:
   - sprite: Mobs/Customization/diona.rsi
     state: laurel
@@ -172,8 +172,8 @@
   coloring:
     default:
       type:
-        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
-          # color: "#FFFFFF"
+        !type:SimpleColoring
+          color: "#FFFFFF"
   sprites:
   - sprite: Mobs/Customization/diona.rsi
     state: leafy
@@ -185,8 +185,8 @@
   coloring:
     default:
       type:
-        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
-          # color: "#FFFFFF"
+        !type:SimpleColoring
+          color: "#FFFFFF"
   sprites:
   - sprite: Mobs/Customization/diona.rsi
     state: lotus
@@ -198,8 +198,8 @@
   coloring:
     default:
       type:
-        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
-          # color: "#FFFFFF"
+        !type:SimpleColoring
+          color: "#FFFFFF"
   sprites:
   - sprite: Mobs/Customization/diona.rsi
     state: meadow
@@ -211,8 +211,8 @@
   coloring:
     default:
       type:
-        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
-          # color: "#FFFFFF"
+        !type:SimpleColoring
+          color: "#FFFFFF"
   sprites:
   - sprite: Mobs/Customization/diona.rsi
     state: oak
@@ -224,8 +224,8 @@
   coloring:
     default:
       type:
-        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
-          # color: "#FFFFFF"
+        !type:SimpleColoring
+          color: "#FFFFFF"
   sprites:
   - sprite: Mobs/Customization/diona.rsi
     state: palm
@@ -237,8 +237,8 @@
   coloring:
     default:
       type:
-        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
-          # color: "#FFFFFF"
+        !type:SimpleColoring
+          color: "#FFFFFF"
   sprites:
   - sprite: Mobs/Customization/diona.rsi
     state: root
@@ -250,8 +250,8 @@
   coloring:
     default:
       type:
-        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
-          # color: "#FFFFFF"
+        !type:SimpleColoring
+          color: "#FFFFFF"
   sprites:
   - sprite: Mobs/Customization/diona.rsi
     state: rose
@@ -263,8 +263,8 @@
   coloring:
     default:
       type:
-        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
-          # color: "#FFFFFF"
+        !type:SimpleColoring
+          color: "#FFFFFF"
   sprites:
   - sprite: Mobs/Customization/diona.rsi
     state: rosey
@@ -276,8 +276,8 @@
   coloring:
     default:
       type:
-        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
-          # color: "#FFFFFF"
+        !type:SimpleColoring
+          color: "#FFFFFF"
   sprites:
   - sprite: Mobs/Customization/diona.rsi
     state: shrub
@@ -289,8 +289,8 @@
   coloring:
     default:
       type:
-        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
-          # color: "#FFFFFF"
+        !type:SimpleColoring
+          color: "#FFFFFF"
   sprites:
   - sprite: Mobs/Customization/diona.rsi
     state: spinner
@@ -302,8 +302,8 @@
   coloring:
     default:
       type:
-        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
-          # color: "#FFFFFF"
+        !type:SimpleColoring
+          color: "#FFFFFF"
   sprites:
   - sprite: Mobs/Customization/diona.rsi
     state: sprout
@@ -315,8 +315,8 @@
   coloring:
     default:
       type:
-        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
-          # color: "#FFFFFF"
+        !type:SimpleColoring
+          color: "#FFFFFF"
   sprites:
   - sprite: Mobs/Customization/diona.rsi
     state: vine
@@ -328,8 +328,8 @@
   coloring:
     default:
       type:
-        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
-          # color: "#FFFFFF"
+        !type:SimpleColoring
+          color: "#FFFFFF"
   sprites:
   - sprite: Mobs/Customization/diona.rsi
     state: vinel
@@ -341,8 +341,8 @@
   coloring:
     default:
       type:
-        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
-          # color: "#FFFFFF"
+        !type:SimpleColoring
+          color: "#FFFFFF"
   sprites:
   - sprite: Mobs/Customization/diona.rsi
     state: vines
@@ -354,8 +354,8 @@
   coloring:
     default:
       type:
-        !type:EyeColoring # MACRO SimpleColoring -> EyeColoring
-          #color: "#FFFFFF"
+        !type:SimpleColoring
+          color: "#FFFFFF"
   sprites:
   - sprite: Mobs/Customization/diona.rsi
     state: wildflower

--- a/Resources/Prototypes/Entities/Mobs/Customization/Markings/scars.yml
+++ b/Resources/Prototypes/Entities/Mobs/Customization/Markings/scars.yml
@@ -5,6 +5,11 @@
   sprites:
   - sprite: Mobs/Customization/scars.rsi
     state: scar_eye_right
+  coloring: # MACRO ADD
+    default:
+      type:
+        !type:TattooColoring
+      fallbackColor: "#666666"
 
 - type: marking
   id: ScarEyeLeft
@@ -13,6 +18,11 @@
   sprites:
   - sprite: Mobs/Customization/scars.rsi
     state: scar_eye_left
+  coloring: # MACRO ADD
+    default:
+      type:
+        !type:TattooColoring
+      fallbackColor: "#666666"
 
 - type: marking
   id: ScarTopSurgeryShort
@@ -22,6 +32,11 @@
   sprites:
   - sprite: Mobs/Customization/scars.rsi
     state: scar_top_surgery_short
+  coloring: # MACRO ADD
+    default:
+      type:
+        !type:TattooColoring
+      fallbackColor: "#666666"
 
 - type: marking
   id: ScarTopSurgeryLong
@@ -31,6 +46,11 @@
   sprites:
   - sprite: Mobs/Customization/scars.rsi
     state: scar_top_surgery_long
+  coloring: # MACRO ADD
+    default:
+      type:
+        !type:TattooColoring
+      fallbackColor: "#666666"
 
 - type: marking
   id: ScarChest
@@ -39,6 +59,11 @@
   sprites:
   - sprite: Mobs/Customization/scars.rsi
     state: scar_chest
+  coloring: # MACRO ADD
+    default:
+      type:
+        !type:TattooColoring
+      fallbackColor: "#666666"
 
 - type: marking
   id: ScarNeck
@@ -47,6 +72,11 @@
   sprites:
   - sprite: Mobs/Customization/scars.rsi
     state: scar_neck
+  coloring: # MACRO ADD
+    default:
+      type:
+        !type:TattooColoring
+      fallbackColor: "#666666"
 
 - type: marking
   id: ScarChestBullets
@@ -55,6 +85,11 @@
   sprites:
   - sprite: Mobs/Customization/scars.rsi
     state: scar_chest_bullets
+  coloring: # MACRO ADD
+    default:
+      type:
+        !type:TattooColoring
+      fallbackColor: "#666666"
 
 - type: marking
   id: ScarStomachBullets
@@ -63,6 +98,11 @@
   sprites:
   - sprite: Mobs/Customization/scars.rsi
     state: scar_stomach_bullets
+  coloring: # MACRO ADD
+    default:
+      type:
+        !type:TattooColoring
+      fallbackColor: "#666666"
 
 - type: marking
   id: ScarFace1
@@ -71,6 +111,11 @@
   sprites:
   - sprite: Mobs/Customization/scars.rsi
     state: scar_face_1
+  coloring: # MACRO ADD
+    default:
+      type:
+        !type:TattooColoring
+      fallbackColor: "#666666"
 
 - type: marking
   id: ScarFace2
@@ -79,6 +124,11 @@
   sprites:
   - sprite: Mobs/Customization/scars.rsi
     state: scar_face_2
+  coloring: # MACRO ADD
+    default:
+      type:
+        !type:TattooColoring
+      fallbackColor: "#666666"
 
 - type: marking
   id: ScarEyeRightSmall
@@ -87,6 +137,11 @@
   sprites:
   - sprite: Mobs/Customization/scars.rsi
     state: scar_eye_right_small
+  coloring: # MACRO ADD
+    default:
+      type:
+        !type:TattooColoring
+      fallbackColor: "#666666"
 
 - type: marking
   id: ScarEyeLeftSmall
@@ -95,3 +150,8 @@
   sprites:
   - sprite: Mobs/Customization/scars.rsi
     state: scar_eye_left_small
+  coloring: # MACRO ADD
+    default:
+      type:
+        !type:TattooColoring
+      fallbackColor: "#666666"

--- a/Resources/Prototypes/Entities/Mobs/Customization/Markings/undergarments.yml
+++ b/Resources/Prototypes/Entities/Mobs/Customization/Markings/undergarments.yml
@@ -7,8 +7,7 @@
   groupWhitelist: [Arachnid, Diona, Human, Moth, Slime]
   coloring:
     default:
-      type: #null # MACRO remove
-        !type:EyeColoring # MACRO add
+      type: null
       fallbackColor: '#FFFFFF'
   sprites:
   - sprite: Mobs/Customization/undergarments.rsi
@@ -20,8 +19,7 @@
   groupWhitelist: [Arachnid, Diona, Human, Moth, Slime]
   coloring:
     default:
-      type: #null # MACRO remove
-        !type:EyeColoring # MACRO add
+      type: null
       fallbackColor: '#FFFFFF'
   sprites:
   - sprite: Mobs/Customization/undergarments.rsi
@@ -33,8 +31,7 @@
   groupWhitelist: [Arachnid, Diona, Human, Moth, Slime]
   coloring:
     default:
-      type: #null # MACRO remove
-        !type:EyeColoring # MACRO add
+      type: null
       fallbackColor: '#FFFFFF'
   sprites:
   - sprite: Mobs/Customization/undergarments.rsi
@@ -46,8 +43,7 @@
   groupWhitelist: [Arachnid, Diona, Human, Moth, Reptilian, Slime]
   coloring:
     default:
-      type: #null # MACRO remove
-        !type:EyeColoring # MACRO add
+      type: null
       fallbackColor: '#FFFFFF'
   sprites:
   - sprite: Mobs/Customization/undergarments.rsi
@@ -59,8 +55,7 @@
   groupWhitelist: [Arachnid, Diona, Human, Moth, Reptilian, Slime]
   coloring:
     default:
-      type: #null # MACRO remove
-        !type:EyeColoring # MACRO add
+      type: null
       fallbackColor: '#FFFFFF'
   sprites:
   - sprite: Mobs/Customization/undergarments.rsi
@@ -72,8 +67,7 @@
   groupWhitelist: [Arachnid, Diona, Human, Moth, Reptilian, Slime]
   coloring:
     default:
-      type: #null # MACRO remove
-        !type:EyeColoring # MACRO add
+      type: null
       fallbackColor: '#FFFFFF'
   sprites:
   - sprite: Mobs/Customization/undergarments.rsi
@@ -85,8 +79,7 @@
   groupWhitelist: [Arachnid, Diona, Human, Moth, Reptilian, Slime]
   coloring:
     default:
-      type: #null # MACRO remove
-        !type:EyeColoring # MACRO add
+      type: null
       fallbackColor: '#FFFFFF'
   sprites:
   - sprite: Mobs/Customization/undergarments.rsi
@@ -98,8 +91,7 @@
   groupWhitelist: [Vox]
   coloring:
     default:
-      type: #null # MACRO remove
-        !type:EyeColoring # MACRO add
+      type: null
       fallbackColor: '#FFFFFF'
   sprites:
   - sprite: Mobs/Customization/undergarments.rsi
@@ -111,8 +103,7 @@
   groupWhitelist: [Vox]
   coloring:
     default:
-      type: #null # MACRO remove
-        !type:EyeColoring # MACRO add
+      type: null
       fallbackColor: '#FFFFFF'
   sprites:
   - sprite: Mobs/Customization/undergarments.rsi
@@ -124,8 +115,7 @@
   groupWhitelist: [Vox]
   coloring:
     default:
-      type: #null # MACRO remove
-        !type:EyeColoring # MACRO add
+      type: null
       fallbackColor: '#FFFFFF'
   sprites:
   - sprite: Mobs/Customization/undergarments.rsi
@@ -137,8 +127,7 @@
   groupWhitelist: [Vox]
   coloring:
     default:
-      type: #null # MACRO remove
-        !type:EyeColoring # MACRO add
+      type: null
       fallbackColor: '#FFFFFF'
   sprites:
   - sprite: Mobs/Customization/undergarments.rsi
@@ -150,8 +139,7 @@
   groupWhitelist: [Vox]
   coloring:
     default:
-      type: #null # MACRO remove
-        !type:EyeColoring # MACRO add
+      type: null
       fallbackColor: '#FFFFFF'
   sprites:
   - sprite: Mobs/Customization/undergarments.rsi
@@ -163,8 +151,7 @@
   groupWhitelist: [Vox]
   coloring:
     default:
-      type: #null # MACRO remove
-        !type:EyeColoring # MACRO add
+      type: null
       fallbackColor: '#FFFFFF'
   sprites:
   - sprite: Mobs/Customization/undergarments.rsi
@@ -176,8 +163,7 @@
   groupWhitelist: [Vox]
   coloring:
     default:
-      type: #null # MACRO remove
-        !type:EyeColoring # MACRO add
+      type: null
       fallbackColor: '#FFFFFF'
   sprites:
   - sprite: Mobs/Customization/undergarments.rsi
@@ -189,8 +175,7 @@
   groupWhitelist: [Reptilian]
   coloring:
     default:
-      type: #null # MACRO remove
-        !type:EyeColoring # MACRO add
+      type: null
       fallbackColor: '#FFFFFF'
   sprites:
   - sprite: Mobs/Customization/undergarments.rsi
@@ -202,8 +187,7 @@
   groupWhitelist: [Reptilian]
   coloring:
     default:
-      type: #null # MACRO remove
-        !type:EyeColoring # MACRO add
+      type: null
       fallbackColor: '#FFFFFF'
   sprites:
   - sprite: Mobs/Customization/undergarments.rsi
@@ -215,8 +199,7 @@
   groupWhitelist: [Reptilian]
   coloring:
     default:
-      type: #null # MACRO remove
-        !type:EyeColoring # MACRO add
+      type: null
       fallbackColor: '#FFFFFF'
   sprites:
   - sprite: Mobs/Customization/undergarments.rsi
@@ -228,8 +211,7 @@
   groupWhitelist: [Vulpkanin]
   coloring:
     default:
-      type: #null # MACRO remove
-        !type:EyeColoring # MACRO add
+      type: null
       fallbackColor: '#FFFFFF'
   sprites:
   - sprite: Mobs/Customization/undergarments.rsi
@@ -241,8 +223,7 @@
   groupWhitelist: [Vulpkanin]
   coloring:
     default:
-      type: #null # MACRO remove
-        !type:EyeColoring # MACRO add
+      type: null
       fallbackColor: '#FFFFFF'
   sprites:
   - sprite: Mobs/Customization/undergarments.rsi
@@ -254,8 +235,7 @@
   groupWhitelist: [Vulpkanin]
   coloring:
     default:
-      type: #null # MACRO remove
-        !type:EyeColoring # MACRO add
+      type: null
       fallbackColor: '#FFFFFF'
   sprites:
   - sprite: Mobs/Customization/undergarments.rsi
@@ -267,8 +247,7 @@
   groupWhitelist: [Vulpkanin]
   coloring:
     default:
-      type: #null # MACRO remove
-        !type:EyeColoring # MACRO add
+      type: null
       fallbackColor: '#FFFFFF'
   sprites:
   - sprite: Mobs/Customization/undergarments.rsi
@@ -280,8 +259,7 @@
   groupWhitelist: [Vulpkanin]
   coloring:
     default:
-      type: #null # MACRO remove
-        !type:EyeColoring # MACRO add
+      type: null
       fallbackColor: '#FFFFFF'
   sprites:
   - sprite: Mobs/Customization/undergarments.rsi
@@ -293,8 +271,7 @@
   groupWhitelist: [Vulpkanin]
   coloring:
     default:
-      type: #null # MACRO remove
-        !type:EyeColoring # MACRO add
+      type: null
       fallbackColor: '#FFFFFF'
   sprites:
   - sprite: Mobs/Customization/undergarments.rsi
@@ -306,8 +283,7 @@
   groupWhitelist: [Vulpkanin]
   coloring:
     default:
-      type: #null # MACRO remove
-        !type:EyeColoring # MACRO add
+      type: null
       fallbackColor: '#FFFFFF'
   sprites:
   - sprite: Mobs/Customization/undergarments.rsi

--- a/Resources/Prototypes/Entities/Mobs/Customization/Markings/undergarments.yml
+++ b/Resources/Prototypes/Entities/Mobs/Customization/Markings/undergarments.yml
@@ -1,5 +1,5 @@
 # These options are kept very sparse to not put emphasis on nudity, and to provide a base for players to feel comfortable with.
-# It's unlikely more will be added to upstream for cosmetic reasons. 
+# It's unlikely more will be added to upstream for cosmetic reasons.
 
 - type: marking
   id: UndergarmentBottomBoxers
@@ -7,7 +7,8 @@
   groupWhitelist: [Arachnid, Diona, Human, Moth, Slime]
   coloring:
     default:
-      type: null
+      type: #null # MACRO remove
+        !type:EyeColoring # MACRO add
       fallbackColor: '#FFFFFF'
   sprites:
   - sprite: Mobs/Customization/undergarments.rsi
@@ -19,7 +20,8 @@
   groupWhitelist: [Arachnid, Diona, Human, Moth, Slime]
   coloring:
     default:
-      type: null
+      type: #null # MACRO remove
+        !type:EyeColoring # MACRO add
       fallbackColor: '#FFFFFF'
   sprites:
   - sprite: Mobs/Customization/undergarments.rsi
@@ -31,7 +33,8 @@
   groupWhitelist: [Arachnid, Diona, Human, Moth, Slime]
   coloring:
     default:
-      type: null
+      type: #null # MACRO remove
+        !type:EyeColoring # MACRO add
       fallbackColor: '#FFFFFF'
   sprites:
   - sprite: Mobs/Customization/undergarments.rsi
@@ -43,7 +46,8 @@
   groupWhitelist: [Arachnid, Diona, Human, Moth, Reptilian, Slime]
   coloring:
     default:
-      type: null
+      type: #null # MACRO remove
+        !type:EyeColoring # MACRO add
       fallbackColor: '#FFFFFF'
   sprites:
   - sprite: Mobs/Customization/undergarments.rsi
@@ -55,7 +59,8 @@
   groupWhitelist: [Arachnid, Diona, Human, Moth, Reptilian, Slime]
   coloring:
     default:
-      type: null
+      type: #null # MACRO remove
+        !type:EyeColoring # MACRO add
       fallbackColor: '#FFFFFF'
   sprites:
   - sprite: Mobs/Customization/undergarments.rsi
@@ -67,7 +72,8 @@
   groupWhitelist: [Arachnid, Diona, Human, Moth, Reptilian, Slime]
   coloring:
     default:
-      type: null
+      type: #null # MACRO remove
+        !type:EyeColoring # MACRO add
       fallbackColor: '#FFFFFF'
   sprites:
   - sprite: Mobs/Customization/undergarments.rsi
@@ -79,7 +85,8 @@
   groupWhitelist: [Arachnid, Diona, Human, Moth, Reptilian, Slime]
   coloring:
     default:
-      type: null
+      type: #null # MACRO remove
+        !type:EyeColoring # MACRO add
       fallbackColor: '#FFFFFF'
   sprites:
   - sprite: Mobs/Customization/undergarments.rsi
@@ -91,7 +98,8 @@
   groupWhitelist: [Vox]
   coloring:
     default:
-      type: null
+      type: #null # MACRO remove
+        !type:EyeColoring # MACRO add
       fallbackColor: '#FFFFFF'
   sprites:
   - sprite: Mobs/Customization/undergarments.rsi
@@ -103,7 +111,8 @@
   groupWhitelist: [Vox]
   coloring:
     default:
-      type: null
+      type: #null # MACRO remove
+        !type:EyeColoring # MACRO add
       fallbackColor: '#FFFFFF'
   sprites:
   - sprite: Mobs/Customization/undergarments.rsi
@@ -115,7 +124,8 @@
   groupWhitelist: [Vox]
   coloring:
     default:
-      type: null
+      type: #null # MACRO remove
+        !type:EyeColoring # MACRO add
       fallbackColor: '#FFFFFF'
   sprites:
   - sprite: Mobs/Customization/undergarments.rsi
@@ -127,7 +137,8 @@
   groupWhitelist: [Vox]
   coloring:
     default:
-      type: null
+      type: #null # MACRO remove
+        !type:EyeColoring # MACRO add
       fallbackColor: '#FFFFFF'
   sprites:
   - sprite: Mobs/Customization/undergarments.rsi
@@ -139,7 +150,8 @@
   groupWhitelist: [Vox]
   coloring:
     default:
-      type: null
+      type: #null # MACRO remove
+        !type:EyeColoring # MACRO add
       fallbackColor: '#FFFFFF'
   sprites:
   - sprite: Mobs/Customization/undergarments.rsi
@@ -151,7 +163,8 @@
   groupWhitelist: [Vox]
   coloring:
     default:
-      type: null
+      type: #null # MACRO remove
+        !type:EyeColoring # MACRO add
       fallbackColor: '#FFFFFF'
   sprites:
   - sprite: Mobs/Customization/undergarments.rsi
@@ -163,7 +176,8 @@
   groupWhitelist: [Vox]
   coloring:
     default:
-      type: null
+      type: #null # MACRO remove
+        !type:EyeColoring # MACRO add
       fallbackColor: '#FFFFFF'
   sprites:
   - sprite: Mobs/Customization/undergarments.rsi
@@ -175,7 +189,8 @@
   groupWhitelist: [Reptilian]
   coloring:
     default:
-      type: null
+      type: #null # MACRO remove
+        !type:EyeColoring # MACRO add
       fallbackColor: '#FFFFFF'
   sprites:
   - sprite: Mobs/Customization/undergarments.rsi
@@ -187,7 +202,8 @@
   groupWhitelist: [Reptilian]
   coloring:
     default:
-      type: null
+      type: #null # MACRO remove
+        !type:EyeColoring # MACRO add
       fallbackColor: '#FFFFFF'
   sprites:
   - sprite: Mobs/Customization/undergarments.rsi
@@ -199,7 +215,8 @@
   groupWhitelist: [Reptilian]
   coloring:
     default:
-      type: null
+      type: #null # MACRO remove
+        !type:EyeColoring # MACRO add
       fallbackColor: '#FFFFFF'
   sprites:
   - sprite: Mobs/Customization/undergarments.rsi
@@ -211,7 +228,8 @@
   groupWhitelist: [Vulpkanin]
   coloring:
     default:
-      type: null
+      type: #null # MACRO remove
+        !type:EyeColoring # MACRO add
       fallbackColor: '#FFFFFF'
   sprites:
   - sprite: Mobs/Customization/undergarments.rsi
@@ -223,7 +241,8 @@
   groupWhitelist: [Vulpkanin]
   coloring:
     default:
-      type: null
+      type: #null # MACRO remove
+        !type:EyeColoring # MACRO add
       fallbackColor: '#FFFFFF'
   sprites:
   - sprite: Mobs/Customization/undergarments.rsi
@@ -235,7 +254,8 @@
   groupWhitelist: [Vulpkanin]
   coloring:
     default:
-      type: null
+      type: #null # MACRO remove
+        !type:EyeColoring # MACRO add
       fallbackColor: '#FFFFFF'
   sprites:
   - sprite: Mobs/Customization/undergarments.rsi
@@ -247,7 +267,8 @@
   groupWhitelist: [Vulpkanin]
   coloring:
     default:
-      type: null
+      type: #null # MACRO remove
+        !type:EyeColoring # MACRO add
       fallbackColor: '#FFFFFF'
   sprites:
   - sprite: Mobs/Customization/undergarments.rsi
@@ -259,7 +280,8 @@
   groupWhitelist: [Vulpkanin]
   coloring:
     default:
-      type: null
+      type: #null # MACRO remove
+        !type:EyeColoring # MACRO add
       fallbackColor: '#FFFFFF'
   sprites:
   - sprite: Mobs/Customization/undergarments.rsi
@@ -271,7 +293,8 @@
   groupWhitelist: [Vulpkanin]
   coloring:
     default:
-      type: null
+      type: #null # MACRO remove
+        !type:EyeColoring # MACRO add
       fallbackColor: '#FFFFFF'
   sprites:
   - sprite: Mobs/Customization/undergarments.rsi
@@ -283,9 +306,9 @@
   groupWhitelist: [Vulpkanin]
   coloring:
     default:
-      type: null
+      type: #null # MACRO remove
+        !type:EyeColoring # MACRO add
       fallbackColor: '#FFFFFF'
   sprites:
   - sprite: Mobs/Customization/undergarments.rsi
     state: tanktop_vulpkanin
-    

--- a/Resources/Prototypes/Entities/Mobs/Customization/Markings/vox_scars.yml
+++ b/Resources/Prototypes/Entities/Mobs/Customization/Markings/vox_scars.yml
@@ -5,6 +5,11 @@
   sprites:
   - sprite: Mobs/Customization/vox_scars.rsi
     state: vox_scar_eye_right
+  coloring: # MACRO ADD
+    default:
+      type:
+        !type:TattooColoring
+      fallbackColor: "#666666"
 
 - type: marking
   id: VoxScarEyeLeft
@@ -13,6 +18,11 @@
   sprites:
   - sprite: Mobs/Customization/vox_scars.rsi
     state: vox_scar_eye_left
+  coloring: # MACRO ADD
+    default:
+      type:
+        !type:TattooColoring
+      fallbackColor: "#666666"
 
 - type: marking
   id: VoxScarTopSurgeryShort
@@ -21,6 +31,11 @@
   sprites:
   - sprite: Mobs/Customization/vox_scars.rsi
     state: vox_top_surgery_short
+  coloring: # MACRO ADD
+    default:
+      type:
+        !type:TattooColoring
+      fallbackColor: "#666666"
 
 - type: marking
   id: VoxScarTopSurgeryLong
@@ -29,6 +44,11 @@
   sprites:
   - sprite: Mobs/Customization/vox_scars.rsi
     state: vox_top_surgery_long
+  coloring: # MACRO ADD
+    default:
+      type:
+        !type:TattooColoring
+      fallbackColor: "#666666"
 
 - type: marking
   id: VoxScarChest
@@ -37,6 +57,11 @@
   sprites:
   - sprite: Mobs/Customization/vox_scars.rsi
     state: vox_scar_chest
+  coloring: # MACRO ADD
+    default:
+      type:
+        !type:TattooColoring
+      fallbackColor: "#666666"
 
 - type: marking
   id: VoxScarNeck
@@ -45,6 +70,11 @@
   sprites:
   - sprite: Mobs/Customization/vox_scars.rsi
     state: vox_scar_neck
+  coloring: # MACRO ADD
+    default:
+      type:
+        !type:TattooColoring
+      fallbackColor: "#666666"
 
 - type: marking
   id: VoxScarChestBullets
@@ -53,6 +83,11 @@
   sprites:
   - sprite: Mobs/Customization/vox_scars.rsi
     state: vox_scar_chest_bullets
+  coloring: # MACRO ADD
+    default:
+      type:
+        !type:TattooColoring
+      fallbackColor: "#666666"
 
 - type: marking
   id: VoxScarStomachBullets
@@ -61,6 +96,11 @@
   sprites:
   - sprite: Mobs/Customization/vox_scars.rsi
     state: vox_scar_stomach_bullets
+  coloring: # MACRO ADD
+    default:
+      type:
+        !type:TattooColoring
+      fallbackColor: "#666666"
 
 - type: marking
   id: VoxScarFace1
@@ -69,6 +109,11 @@
   sprites:
   - sprite: Mobs/Customization/vox_scars.rsi
     state: vox_scar_face_1
+  coloring: # MACRO ADD
+    default:
+      type:
+        !type:TattooColoring
+      fallbackColor: "#666666"
 
 - type: marking
   id: VoxScarFace2
@@ -77,6 +122,11 @@
   sprites:
   - sprite: Mobs/Customization/vox_scars.rsi
     state: vox_scar_face_2
+  coloring: # MACRO ADD
+    default:
+      type:
+        !type:TattooColoring
+      fallbackColor: "#666666"
 
 - type: marking
   id: VoxScarEyeRightSmall
@@ -85,6 +135,11 @@
   sprites:
   - sprite: Mobs/Customization/vox_scars.rsi
     state: vox_scar_eye_right_small
+  coloring: # MACRO ADD
+    default:
+      type:
+        !type:TattooColoring
+      fallbackColor: "#666666"
 
 - type: marking
   id: VoxScarEyeLeftSmall
@@ -93,3 +148,8 @@
   sprites:
   - sprite: Mobs/Customization/vox_scars.rsi
     state: vox_scar_eye_left_small
+  coloring: # MACRO ADD
+    default:
+      type:
+        !type:TattooColoring
+      fallbackColor: "#666666"

--- a/Resources/Prototypes/Species/skin_colorations.yml
+++ b/Resources/Prototypes/Species/skin_colorations.yml
@@ -8,6 +8,7 @@
   strategy: !type:ClampedHslColoration
     saturation: [0, 0.1]
     lightness: [0.85, 1]
+  squashAllColors: true # MACRO
 
 - type: skinColoration
   id: VoxFeathers
@@ -19,9 +20,11 @@
 - type: skinColoration
   id: HumanToned
   strategy: !type:HumanTonedSkinColoration {}
+  realisticColors: true # MACRO
 
 - type: skinColoration
   id: VulpkaninColors
   strategy: !type:ClampedHslColoration
     saturation: [0.0, 0.60]
     lightness: [0.2, 0.9]
+  squashAllColors: true # MACRO


### PR DESCRIPTION
## About the PR
Port of:
- https://github.com/impstation/imp-station-14/pull/1600
- https://github.com/impstation/imp-station-14/pull/2148
- https://github.com/impstation/imp-station-14/pull/2149
- https://github.com/impstation/imp-station-14/pull/2855

Allows players to randomize the appearance of a character in the character creation UI without modifying the name, species, sex, or age. Also ensures that randomly generated characters will have markings, and prettier-looking colours.

On the dev side, this also allows markings/species authors to fine-tune random generation of markings on a species, determining the chance of rolling markings on individual categories, or even making some markings rarer than others.

I've given humans, voxes, slimes, vulps, and species that use `TintedHues` some parameters to generate what i consider nicer-looking characters by default. These can all be altered as desired.

I've also changed some of the default color parameters in various species markings. These changes are very minorly player-facing as they just change the default colour of the new marking when it's added.

## Why / Balance
RANDOM MARKINGS: needed soooo so badly
APPEARANCE BUTTON: a blessing

MARKING WEIGHTS: okay, bear with me here. These were initially added on Imp because the authors of species wanted to include rare markings that had a small chance to roll on ghostrole species (as an example, the cat ears). But they also found another use in guaranteeing that certain species don't have a 60% chance to wind up with the default markings.
The linked PR has an example of this for the Imp Kodepiia species. check it out

## Technical details
All the code from the initial Imp PRs has been completely refactored, both to work with nubody and also to do some general cleanup.

In addition to modifying `HumanoidCharacterAppearance`, Ive added a new partial class `HumanoidCharacterAppearance.Random` which contains the bulk of helper methods involved in handing random markings for a layer, random color generation, etc. All methods have been commented, but please let me know if more documentation is desired as i have removed a lot of beck's comments in the process of reworking this.

Anyway, there's lots going on under the hood here. At the moment when we generate a character, the palette will either be a split complimentary, a triadic complimentary, or a plain complimentary- either way, we get 3 colours, where the base colour used is assigned to skintone and the other 2 become eye and hair colours. When we add a marking to our doll, we will colour each layer of a marking by first checking to see if that layer has a defined `MarkingColoring`. If it does, we'll colour it using those rules. Otherwise, we'll pick either the hair or eye color at random.

There are also 2 new `SkinColorationPrototype` parameters. I elaborate on these more below in the breaking changes, but these parameters serve as replacements for upstream behavior that I commented out in the editing of this system.

We cycle through organs -> `HumanoidVisualLayers` in that organ, then add markings to the organ. Each `HumanoidVisualLayers` layer enters a loop where it first checks the layer weight to see if a marking should roll at all (would look pretty chaotic if we always rolled max markings), then gets a random marking from that category. This loop is repeated a number of times equal to the value that layer has in the species `MarkingLimits.Limit`. These markings are all eventually collected in a dictionary which is used to construct our final `HumanoidCharacterAppearance`.

## Rambling about color

I have too many thoughts and feelings about randomization. apologies in advance

Hair and facial hair supposedly now function more similarly to other markings than they did pre-nubody, which is great- theyve always been a weird exception. (Apparently they are however still different enough to require their own generation rules. That's fine.) Fundamentally, not every species will have hair, the same way not every species will have, say, a tail. So it makes sense for nubody to update `HumanoidCharacterAppearance` and remove the requirement that every species generates a hair colour, since they aren't all using it!

The best way to assign markings colours is by using the archaic `MarkingColoring` system, as it has a lot of validation rules which come in handy when importing characters: if the file you import is slightly off, then instead of your character being imported with bright white markings, the markings will use a 'default' colour- your skin tone, the color of other markings, or even a darker variation of your skin tone (this is the tattoo default coloring!). All the values are taken from the colors in `HumanoidCharacterAppearance`.

You might be able to predict the trouble I ran into here by combining these two facts. The issue that comes with this is that we are (using the pre-nubody random system, which i did spend a long time iterating on) generating a palette with 3 tones: skin, hair, and eyes.

*However, since `HumanoidCharacterAppearance` no longer stores a hair colour, we are unable to use `MarkingColoring` to assign markings this colour, which means we are limited to using two colours in our randomly generated palette.*

THE SOLUTION: Fallback colours. `MarkingColoring` has three datafields - a nullable `Type`, a list `FallbackTypes`, and a color `FallbackColor`. What's supposed to happen is that those three types will get used in descending order, depending on availability- if a type is not provided, you use the fallback type, and if thats not there you use the fallback color. In upstream, however, the nullable `Type` is always set to `SkinColoring`, so these fallbacks rarely if ever get used.

What I've done is removed the default value from `Type`, and moved `SkinColoring` to `FallbackTypes` if that list is undefined. If the system cannot find a `Type`, it will randomly use either hair or eye color. If it does find a type, it will use that instead!

This solution is a bit unorthodox, but its making edits to a 3-year old system which I suspect has outlived its original purpose for marking coloration. It allows users to use yaml to customize what randomization looks like on a per-marking basis, which is my main goal with this PR!

## Media

https://github.com/user-attachments/assets/beb7000c-8be2-4c4e-9c07-7a4b71d57815

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the Macrocosm [Pull Request Conventions ](https://docs.macrocosm.cool/docs/Conventions/pull-requests/).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
A new button has been added to the character creation UI to randomize only a character's appearance. To disable this feature, you can comment out the button in XAML.

In addition, randomly generated characters will now roll markings! The rarity of markings can be altered per species. To modify the chance that a marking will randomly roll for an entire category, use `MarkingsGroupPrototype.Weight`. To modify the weight of an individual marking rolling over other markings in that category, use `MarkingPrototype.RandomWeight`.

Species `SkinColorationPrototypes` now have additional options `RealisticColors` and `SquashAllColors`, which can be toggled on per prototype to generate more realistic colours. As an example, `RealisticColors` can be used for humans to generate only real-world hair and eye colours, while `SquashAllColors` can be used to make vulpkanin fur tones more realistic.

`MarkingColoration` now has its default value for `Type` set to null, with `SkinColoring` being moved to `FallbackTypes`.

Some markings have also had their default coloring altered. These can be modified as desired.

**Changelog**
:cl: widgetbeck, mqole
- add: Randomized characters will now roll markings.
- add: Added a 'Randomize Appearance' button to the character customization UI.
