### PR TITLE
[MACRO] Allow different bwoink sounds for Players and Admins

### DIFF
--- a/Content.Client/UserInterface/Systems/Bwoink/AHelpUIController.cs
+++ b/Content.Client/UserInterface/Systems/Bwoink/AHelpUIController.cs
@@ -10,6 +10,7 @@ using Content.Client.Lobby.UI;
 using Content.Client.Stylesheets;
 using Content.Client.UserInterface.Controls;
 using Content.Client.UserInterface.Systems.MenuBar.Widgets;
+using Content.Shared._MACRO.MCCVar.CCVar;
 using Content.Shared.Administration;
 using Content.Shared.CCVar;
 using Content.Shared.Input;
@@ -64,7 +65,7 @@ public sealed class AHelpUIController: UIController, IOnSystemChanged<BwoinkSyst
         _config.OnValueChanged(CCVars.AHelpSound, v => _aHelpSound = v, true);
         _config.OnValueChanged(CCVars.BwoinkSoundEnabled, v => _bwoinkSoundEnabled = v, true);
         // MACRO start
-        _config.OnValueChanged(Shared._MACRO.CCVar.CCVars.AHelpAdminSound, v => _aHelpAdminSound = v, true);
+        _config.OnValueChanged(MCCVars.AHelpAdminSound, v => _aHelpAdminSound = v, true);
         // MACRO end
     }
 

--- a/Content.Client/UserInterface/Systems/Bwoink/AHelpUIController.cs
+++ b/Content.Client/UserInterface/Systems/Bwoink/AHelpUIController.cs
@@ -49,6 +49,7 @@ public sealed class AHelpUIController: UIController, IOnSystemChanged<BwoinkSyst
     private bool _hasUnreadAHelp;
     private bool _bwoinkSoundEnabled;
     private string? _aHelpSound;
+    private string? _aHelpAdminSound; // MACRO
 
     protected override string SawmillName => "c.s.go.es.bwoink";
 
@@ -62,6 +63,9 @@ public sealed class AHelpUIController: UIController, IOnSystemChanged<BwoinkSyst
         _adminManager.AdminStatusUpdated += OnAdminStatusUpdated;
         _config.OnValueChanged(CCVars.AHelpSound, v => _aHelpSound = v, true);
         _config.OnValueChanged(CCVars.BwoinkSoundEnabled, v => _bwoinkSoundEnabled = v, true);
+        // MACRO start
+        _config.OnValueChanged(Shared._MACRO.CCVar.CCVars.AHelpAdminSound, v => _aHelpAdminSound = v, true);
+        // MACRO end
     }
 
     public void UnloadButton()
@@ -139,8 +143,11 @@ public sealed class AHelpUIController: UIController, IOnSystemChanged<BwoinkSyst
         }
         if (message.PlaySound && localPlayer.UserId != message.TrueSender)
         {
-            if (_aHelpSound != null && (_bwoinkSoundEnabled || !_adminManager.IsActive()))
-                _audio.PlayGlobal(_aHelpSound, Filter.Local(), false);
+            // MACRO start
+            var sound = _adminManager.IsActive() ? _aHelpAdminSound : _aHelpSound;
+            if (sound != null && (_bwoinkSoundEnabled || !_adminManager.IsActive()))
+                _audio.PlayGlobal(sound, Filter.Local(), false);
+            // MACRO end
             _clyde.RequestWindowAttention();
         }
 

--- a/Content.Client/UserInterface/Systems/Bwoink/AHelpUIController.cs
+++ b/Content.Client/UserInterface/Systems/Bwoink/AHelpUIController.cs
@@ -10,7 +10,7 @@ using Content.Client.Lobby.UI;
 using Content.Client.Stylesheets;
 using Content.Client.UserInterface.Controls;
 using Content.Client.UserInterface.Systems.MenuBar.Widgets;
-using Content.Shared._MACRO.MCCVar.CCVar;
+using Content.Shared._MACRO.MCCVar;
 using Content.Shared.Administration;
 using Content.Shared.CCVar;
 using Content.Shared.Input;

--- a/Content.Shared/_MACRO/CCVar/CCVars.Sounds.cs
+++ b/Content.Shared/_MACRO/CCVar/CCVars.Sounds.cs
@@ -1,0 +1,13 @@
+using Robust.Shared.Configuration;
+
+namespace Content.Shared._MACRO.CCVar;
+
+[CVarDefs]
+public sealed partial class CCVars
+{
+    /// <summary>
+    /// This is what currently adminned players hear when they get an ahelp.
+    /// </summary>
+    public static readonly CVarDef<string> AHelpAdminSound =
+        CVarDef.Create("audio.ahelp_admin_sound", "/Audio/Effects/adminhelp.ogg", CVar.ARCHIVE | CVar.CLIENTONLY);
+}

--- a/Content.Shared/_MACRO/MCCVar/MCCVars.Sounds.cs
+++ b/Content.Shared/_MACRO/MCCVar/MCCVars.Sounds.cs
@@ -1,9 +1,12 @@
 using Robust.Shared.Configuration;
 
-namespace Content.Shared._MACRO.CCVar;
+namespace Content.Shared._MACRO.MCCVar;
 
+// This is the first file made, so I'll put it here.
+// Why MCCVars?
+// M stands for Macro, so imports are a lot nicer.
 [CVarDefs]
-public sealed partial class CCVars
+public sealed partial class MCCVars
 {
     /// <summary>
     /// This is what currently adminned players hear when they get an ahelp.


### PR DESCRIPTION
## About the PR
Adds a new CVar called `audio.ahelp_admin_sound` that lets server hosts control what sound gets played when an ahelp is received for admins.

## Why / Balance
N/A

## Technical details
Added a new folder called MCCVars, with the `M` adding a nice way for us to easily tell in-code what is a Macro unique feature flag.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the Macrocosm [Pull Request Conventions ](https://docs.macrocosm.cool/docs/Conventions/pull-requests/).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None. To enable, simply find the string `audio.ahelp_admin_sound` and change the path.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
The name that appears on the changelog will be your GitHub username by default. If you wish for a different name to appear, format the symbol like so:
:cl: My Name -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
No changelog needed.