### PR TITLE
[CAT D] Ovinia Voice Selector Localization Fix

### DIFF
--- a/Resources/Prototypes/_MACRO/Species/ovinia.yml
+++ b/Resources/Prototypes/_MACRO/Species/ovinia.yml
@@ -14,6 +14,9 @@
   - Male
   - Female
   - Unsexed
+  voices:
+  - MaleOvinia
+  - FemaleOvinia
   defaultSoundsBySex:
   - MaleOvinia
   - FemaleOvinia

--- a/Resources/Prototypes/_MACRO/Voice/ovinia.yml
+++ b/Resources/Prototypes/_MACRO/Voice/ovinia.yml
@@ -18,6 +18,7 @@
 
 - type: emoteSounds
   id: MaleOvinia
+  voiceSelectorName: humanoid-profile-editor-voice-masculine
   params:
     variation: 0.125
   sounds:
@@ -56,6 +57,7 @@
 
 - type: emoteSounds
   id: FemaleOvinia
+  voiceSelectorName: humanoid-profile-editor-voice-feminine
   params:
     variation: 0.125
   sounds:


### PR DESCRIPTION
voice selector said "Unnamed Voice" on both voice selector options for ovinia.

now it'll say "Masculine" and "Feminine" voice types. yay!

:cl:
- fix: Fixed the voice selector for Ovinia having Unnamed Voice for both options.