### PR TITLE
chore: add "how to enable/disable" to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,6 +3,15 @@
 ## About the PR
 <!-- What did you change? -->
 
+### How to enable / disable
+<!--
+    According to our Conventions, all new content added should be easy for a downstream to disable or opt-out of.
+    Content can be opt-out (or opt-in) through the use of CVars, simple YML changes, or simply by not using a feature (if it is made optional in some way, like a mapped entity or an admin-only commmand).
+
+    Explain below how to enable or disable this content. If this is a bugfix, tweak, or a "non-content" change,
+    this section can be omitted.
+-->
+
 ## Why / Balance
 <!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.macrocosm.cool/docs/intro -->

## About the PR
<!-- What did you change? -->
This PR adds a section to PRs for writing enable/disable instructions.

### How to enable / disable
<!--
    According to our Conventions, all new content added should be easy for a downstream to disable or opt-out of.
    Content can be opt-out (or opt-in) through the use of CVars, simple YML changes, or simply by not using a feature (if it is made optional in some way, like a mapped entity or an admin-only commmand).
    Explain below how to enable or disable this content. If this is a bugfix, tweak, or a "non-content" change,
    this section can be omitted.
-->
Merge the pull request.
Downstreams can (and probably should) remove this section by removing this PR's additions.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Helpful for downstreams, enforcement of PR conventions

## Technical details
<!-- Summary of code changes for easier review. -->
Markdown edit

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
Make a pull request (after this one is merged)

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the Macrocosm [Pull Request Conventions](https://docs.macrocosm.cool/docs/Conventions/pull-requests/).