### PR TITLE
fix(kodepiia): correctly disable gibbing if GibThreshold is set to "0"

### DIFF
--- a/Content.Shared/_MACRO/Species/Kodepiia/Consume/SharedConsumeSystem.cs
+++ b/Content.Shared/_MACRO/Species/Kodepiia/Consume/SharedConsumeSystem.cs
@@ -298,7 +298,7 @@ public abstract partial class SharedConsumeSystem : EntitySystem
         Dirty(target, consumed);
 
         // Gib if we exceed the threshold
-        if (_gibThreshold >= 0 && consumed.ConsumedValue >= _gibThreshold)
+        if (_gibThreshold > 0 && consumed.ConsumedValue >= _gibThreshold)
         {
             _gibbing.Gib(target);
             return;


### PR DESCRIPTION
<!-- Guidelines: https://docs.macrocosm.cool/docs/intro --> 
my bad

## About the PR
<!-- What did you change? -->
this PR makes it so that setting `macrocosm.consumption.gib_threshold` to 0 actually disables gibbing via kodepiia's "consume" action

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
the comment for the CVar in the code says that setting it to 0 should disable gibbing, but it did not - instead setting it to 0 would've made the target instagib on first bite. this solves that

## Technical details
<!-- Summary of code changes for easier review. -->
changed a `>=` to `>`

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
set the `macrocosm.consumption.gib_threshold` CVar to `0` and ensure consume targets do not gib on first bite

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc). -->

https://github.com/user-attachments/assets/e833dd18-dd96-4542-9eed-d43f77046437

cooldown of "consume" action was reduced for the sake of example for testing

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the Macrocosm [Pull Request Conventions](https://docs.macrocosm.cool/docs/Conventions/pull-requests/).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
The name that appears on the changelog will be your GitHub username by default. If you wish for a different name to appear, format the symbol like so:
:cl: My Name -->
:cl:
- fix: Setting the `macrocosm.consumption.gib_threshold` to `0` will now stop Kodepiia from being able to gib corpses, instead of making them do so on the first nibble.