### PR TITLE
fix(ungu): raise max age of Ungu to 999

### DIFF
--- a/Resources/Prototypes/_MACRO/Species/ungu.yml
+++ b/Resources/Prototypes/_MACRO/Species/ungu.yml
@@ -1,7 +1,7 @@
 - type: species
   id: Ungu
   name: species-name-ungu
-  roundStart: true
+  roundStart: false
   #randomViable: true
   prototype: MobUngu
   dollPrototype: AppearanceUngu

--- a/Resources/Prototypes/_MACRO/Species/ungu.yml
+++ b/Resources/Prototypes/_MACRO/Species/ungu.yml
@@ -1,7 +1,7 @@
 - type: species
   id: Ungu
   name: species-name-ungu
-  roundStart: false
+  roundStart: true
   #randomViable: true
   prototype: MobUngu
   dollPrototype: AppearanceUngu
@@ -16,6 +16,10 @@
   - Female
   youngAge: 60
   oldAge: 150
+  maxAge: 999
+  # Originally designed for a server (Impstation) with this max age range;
+  # since 150 (old age) > 120 (default max age) we have to adjust the age range anyway.
+  # Might as well let Ungu players have accurate ages.
   defaultSoundsBySex:
   - UnisexUngu
   - UnisexUngu


### PR DESCRIPTION
<!-- Guidelines: https://docs.macrocosm.cool/docs/intro -->
## About the PR
This PR raises the maximum selectable age of Ungu to 999.

### How to enable / disable
Can be reverted by commenting out the `maxAge` line in the Ungu species prototype.

## Why / Balance
Test fail caused by the Ungu "old age" threshold (150) being higher than the default max age (120).

## Technical details
Set the max age of Ungu to 999.

## Test plan
Make an Ungu character with an age above 120.

## Media
<img width="233" height="127" alt="image" src="https://github.com/user-attachments/assets/bd33646e-30fc-41ea-9721-851e08a49fd2" />

## Requirements
- [x] I have read and am following the Macrocosm [Pull Request Conventions](https://docs.macrocosm.cool/docs/Conventions/pull-requests/).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
Nada.

## Changelog
:cl:
- tweak: Ungu can now have a maximum age of 999 - closer to the original intent of the species (which have an old age threshold of 150).
