### PR TITLE
FEATURE: Status effect popup messages and duration condition

### DIFF
--- a/Content.Shared/EntityEffects/Effects/Transform/PopupMessageEntityEffectSystem.cs
+++ b/Content.Shared/EntityEffects/Effects/Transform/PopupMessageEntityEffectSystem.cs
@@ -1,4 +1,5 @@
-﻿using Content.Shared.Popups;
+﻿using Content.Shared.Mobs;
+using Content.Shared.Popups;
 using Robust.Shared.Network;
 using Robust.Shared.Random;
 using Robust.Shared.Serialization;
@@ -17,27 +18,35 @@ public sealed partial class PopupMessageEntityEffectSystem : EntityEffectSystem<
 
     protected override void Effect(Entity<TransformComponent> entity, ref EntityEffectEvent<PopupMessage> args)
     {
-        // TODO: When we get proper random prediction remove this check.
-        if (_net.IsClient)
-            return;
+        // Begin MACRO: Move this function out
+        PopupMessage(entity,
+            messages: args.Effect.Messages,
+            popupType: args.Effect.VisualType,
+            method: args.Effect.Method,
+            recipients: args.Effect.Type);
 
-        var msg = Loc.GetString(_random.Pick(args.Effect.Messages), ("entity", entity));
+        // // TODO: When we get proper random prediction remove this check.
+        // if (_net.IsClient)
+        //     return;
 
-        switch ((args.Effect.Method, args.Effect.Type))
-        {
-            case (PopupMethod.PopupEntity, PopupRecipients.Local):
-                _popup.PopupEntity(msg, entity, entity, args.Effect.VisualType);
-                break;
-            case (PopupMethod.PopupEntity, PopupRecipients.Pvs):
-                _popup.PopupEntity(msg, entity, args.Effect.VisualType);
-                break;
-            case (PopupMethod.PopupCoordinates, PopupRecipients.Local):
-                _popup.PopupCoordinates(msg, Transform(entity).Coordinates, entity, args.Effect.VisualType);
-                break;
-            case (PopupMethod.PopupCoordinates, PopupRecipients.Pvs):
-                _popup.PopupCoordinates(msg, Transform(entity).Coordinates, args.Effect.VisualType);
-                break;
-        }
+        // var msg = Loc.GetString(_random.Pick(args.Effect.Messages), ("entity", entity));
+
+        // switch ((args.Effect.Method, args.Effect.Type))
+        // {
+        //     case (PopupMethod.PopupEntity, PopupRecipients.Local):
+        //         _popup.PopupEntity(msg, entity, entity, args.Effect.VisualType);
+        //         break;
+        //     case (PopupMethod.PopupEntity, PopupRecipients.Pvs):
+        //         _popup.PopupEntity(msg, entity, args.Effect.VisualType);
+        //         break;
+        //     case (PopupMethod.PopupCoordinates, PopupRecipients.Local):
+        //         _popup.PopupCoordinates(msg, Transform(entity).Coordinates, entity, args.Effect.VisualType);
+        //         break;
+        //     case (PopupMethod.PopupCoordinates, PopupRecipients.Pvs):
+        //         _popup.PopupCoordinates(msg, Transform(entity).Coordinates, args.Effect.VisualType);
+        //         break;
+        // }
+        // End MACRO
     }
 }
 

--- a/Content.Shared/_MACRO/EntityConditions/Conditions/StatusEffects/StatusEffectDurationConditionSystem.cs
+++ b/Content.Shared/_MACRO/EntityConditions/Conditions/StatusEffects/StatusEffectDurationConditionSystem.cs
@@ -3,7 +3,7 @@ using Content.Shared.StatusEffectNew;
 using Content.Shared.StatusEffectNew.Components;
 using Robust.Shared.Prototypes;
 
-namespace Content.Shared._DEN.EntityCondiitons.Conditions.Body;
+namespace Content.Shared._MACRO.EntityCondiitons.Conditions.StatusEffects;
 
 /// <summary>
 /// Returns true if this entity has a status effect within a certain range of durations.

--- a/Content.Shared/_MACRO/EntityConditions/Conditions/StatusEffects/StatusEffectDurationConditionSystem.cs
+++ b/Content.Shared/_MACRO/EntityConditions/Conditions/StatusEffects/StatusEffectDurationConditionSystem.cs
@@ -1,0 +1,56 @@
+using Content.Shared.EntityConditions;
+using Content.Shared.StatusEffectNew;
+using Content.Shared.StatusEffectNew.Components;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._DEN.EntityCondiitons.Conditions.Body;
+
+/// <summary>
+/// Returns true if this entity has a status effect within a certain range of durations.
+/// </summary>
+/// <inheritdoc cref="EntityConditionSystem{T, TCondition}"/>
+public sealed partial class StatusEffectDurationEntityConditionSystem
+    : EntityConditionSystem<MetaDataComponent, StatusEffectDurationCondition>
+{
+    [Dependency] private StatusEffectsSystem _statusEffects = default!;
+
+    protected override void Condition(Entity<MetaDataComponent> entity,
+        ref EntityConditionEvent<StatusEffectDurationCondition> args)
+    {
+        if (!_statusEffects.TryGetStatusEffect(entity, args.Condition.EffectProto, out var effect)
+            || !TryComp<StatusEffectComponent>(effect, out var statusEffect))
+        {
+            args.Result = args.Condition.Min <= TimeSpan.Zero;
+            return;
+        }
+
+        args.Result = statusEffect.Duration >= args.Condition.Min
+            && statusEffect.Duration <= args.Condition.Max;
+    }
+}
+
+/// <summary>
+///     Represents an entity having a status effect within a certain range of durations.
+/// </summary>
+public sealed partial class StatusEffectDurationCondition : EntityConditionBase<StatusEffectDurationCondition>
+{
+    [DataField]
+    public TimeSpan Min = TimeSpan.Zero;
+
+    [DataField]
+    public TimeSpan Max = TimeSpan.MaxValue;
+
+    [DataField(required: true)]
+    public EntProtoId EffectProto;
+
+    public override string EntityConditionGuidebookText(IPrototypeManager prototype)
+    {
+        if (!prototype.Resolve(EffectProto, out var effectProto))
+            return string.Empty;
+
+        return Loc.GetString("entity-condition-guidebook-status-effect-duration",
+            ("effect", effectProto.Name),
+            ("max", Max == TimeSpan.MaxValue ? int.MaxValue : Max.TotalSeconds),
+            ("min", Min.TotalSeconds));
+    }
+}

--- a/Content.Shared/_MACRO/EntityEffects/Effects/Transform/PopupMessageEntityEffectSystem.cs
+++ b/Content.Shared/_MACRO/EntityEffects/Effects/Transform/PopupMessageEntityEffectSystem.cs
@@ -1,0 +1,50 @@
+using Content.Shared.IdentityManagement;
+using Content.Shared.Popups;
+using Robust.Shared.Random;
+
+namespace Content.Shared.EntityEffects.Effects.Transform;
+
+public sealed partial class PopupMessageEntityEffectSystem
+{
+    /// <summary>
+    ///     Spawns a random popup message on the given entity with the given parameters.
+    /// </summary>
+    /// <param name="entity">The entity to spawn a popup message on.</param>
+    /// <param name="messages">An array of possible random messages.</param>
+    /// <param name="popupType">The visual type of the popup.</param>
+    /// <param name="method">The popup API type to use.</param>
+    /// <param name="recipients">Whether this popup only shows for the entity, or for everyone.</param>
+    /// <remarks>
+    ///     This was extracted from the body of the <see cref="Effect"/> function.
+    /// </remarks>
+    public void PopupMessage(EntityUid entity,
+        string[] messages,
+        PopupType popupType,
+        PopupMethod method,
+        PopupRecipients recipients)
+    {
+        // TODO: When we get proper random prediction remove this check.
+        if (_net.IsClient)
+            return;
+
+        var entityId = Identity.Entity(entity, EntityManager);
+        var msg = Loc.GetString(_random.Pick(messages), ("entity", entityId));
+
+        switch ((method, recipients))
+        {
+            case (PopupMethod.PopupEntity, PopupRecipients.Local):
+                _popup.PopupEntity(msg, entity, entity, popupType);
+                break;
+            case (PopupMethod.PopupEntity, PopupRecipients.Pvs):
+                _popup.PopupEntity(msg, entity, popupType);
+                break;
+            case (PopupMethod.PopupCoordinates, PopupRecipients.Local):
+                _popup.PopupCoordinates(msg, Transform(entity).Coordinates, entity, popupType);
+                break;
+            case (PopupMethod.PopupCoordinates, PopupRecipients.Pvs):
+                var key = GetNetEntity(entity).Id;
+                _popup.PopupCoordinates(msg, Transform(entity).Coordinates, popupType, predictionKey: key);
+                break;
+        }
+    }
+}

--- a/Content.Shared/_MACRO/Popups/Components/ExpiryPopupMessageStatusEffectComponent.cs
+++ b/Content.Shared/_MACRO/Popups/Components/ExpiryPopupMessageStatusEffectComponent.cs
@@ -1,0 +1,13 @@
+namespace Content.Shared._DEN.StatusEffects.Components;
+
+/// <summary>
+///     A status effect that will create a popup message on the entity upon the status effect expiring.
+/// </summary>
+/// <remarks>
+///     This is very similar to the "PopupMessage" entity effect in metabolisms, but rather than
+///     being a chance per metabolism tick, this just shows a random message on expiry -
+///     making it more consistent.
+/// </remarks>
+[RegisterComponent]
+public sealed partial class ExpiryPopupMessageStatusEffectComponent : PopupMessageStatusEffectComponent
+{ }

--- a/Content.Shared/_MACRO/Popups/Components/ExpiryPopupMessageStatusEffectComponent.cs
+++ b/Content.Shared/_MACRO/Popups/Components/ExpiryPopupMessageStatusEffectComponent.cs
@@ -1,4 +1,4 @@
-namespace Content.Shared._DEN.StatusEffects.Components;
+namespace Content.Shared._MACRO.Popups.Components;
 
 /// <summary>
 ///     A status effect that will create a popup message on the entity upon the status effect expiring.

--- a/Content.Shared/_MACRO/Popups/Components/ExpiryPopupMessageStatusEffectComponent.cs
+++ b/Content.Shared/_MACRO/Popups/Components/ExpiryPopupMessageStatusEffectComponent.cs
@@ -1,3 +1,5 @@
+using Robust.Shared.GameStates;
+
 namespace Content.Shared._MACRO.Popups.Components;
 
 /// <summary>
@@ -9,5 +11,6 @@ namespace Content.Shared._MACRO.Popups.Components;
 ///     making it more consistent.
 /// </remarks>
 [RegisterComponent]
+[NetworkedComponent]
 public sealed partial class ExpiryPopupMessageStatusEffectComponent : PopupMessageStatusEffectComponent
 { }

--- a/Content.Shared/_MACRO/Popups/Components/InitialPopupMessageStatusEffectComponent.cs
+++ b/Content.Shared/_MACRO/Popups/Components/InitialPopupMessageStatusEffectComponent.cs
@@ -1,0 +1,16 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._MACRO.Popups.Components;
+
+/// <summary>
+///     A status effect that will create a popup message on the entity on applying it.
+/// </summary>
+/// <remarks>
+///     This is very similar to the "PopupMessage" entity effect in metabolisms, but rather than
+///     being a chance per metabolism tick, this just shows a random message on expiry -
+///     making it more consistent.
+/// </remarks>
+[RegisterComponent]
+[NetworkedComponent]
+public sealed partial class InitialPopupMessageStatusEffectComponent : PopupMessageStatusEffectComponent
+{ }

--- a/Content.Shared/_MACRO/Popups/Components/IntervalPopupMessageStatusEffectComponent.cs
+++ b/Content.Shared/_MACRO/Popups/Components/IntervalPopupMessageStatusEffectComponent.cs
@@ -1,0 +1,25 @@
+namespace Content.Shared._DEN.StatusEffects.Components;
+
+/// <summary>
+///     A status effect that will regularly create a popup message on the entity on a given interval.
+/// </summary>
+/// <remarks>
+///     This is very similar to the "PopupMessage" entity effect in metabolisms, but rather than
+///     being a chance per metabolism tick, this just shows random messages on a given interval -
+///     making it more consistent.
+/// </remarks>
+[RegisterComponent]
+public sealed partial class IntervalPopupMessageStatusEffectComponent : PopupMessageStatusEffectComponent
+{
+    /// <summary>
+    ///     The minimum and maximum time interval that popup messages will be displayed.
+    /// </summary>
+    [DataField]
+    public (TimeSpan Min, TimeSpan Max) Interval = (TimeSpan.FromSeconds(30.0f), TimeSpan.FromSeconds(60.0f));
+
+    /// <summary>
+    ///     The next time we should display a popup message.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite)]
+    public TimeSpan NextPopupTime = TimeSpan.Zero;
+}

--- a/Content.Shared/_MACRO/Popups/Components/IntervalPopupMessageStatusEffectComponent.cs
+++ b/Content.Shared/_MACRO/Popups/Components/IntervalPopupMessageStatusEffectComponent.cs
@@ -1,3 +1,5 @@
+using Robust.Shared.GameStates;
+
 namespace Content.Shared._MACRO.Popups.Components;
 
 /// <summary>
@@ -9,6 +11,7 @@ namespace Content.Shared._MACRO.Popups.Components;
 ///     making it more consistent.
 /// </remarks>
 [RegisterComponent]
+[NetworkedComponent, AutoGenerateComponentState, AutoGenerateComponentPause]
 public sealed partial class IntervalPopupMessageStatusEffectComponent : PopupMessageStatusEffectComponent
 {
     /// <summary>
@@ -21,5 +24,6 @@ public sealed partial class IntervalPopupMessageStatusEffectComponent : PopupMes
     ///     The next time we should display a popup message.
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]
+    [AutoNetworkedField, AutoPausedField]
     public TimeSpan NextPopupTime = TimeSpan.Zero;
 }

--- a/Content.Shared/_MACRO/Popups/Components/IntervalPopupMessageStatusEffectComponent.cs
+++ b/Content.Shared/_MACRO/Popups/Components/IntervalPopupMessageStatusEffectComponent.cs
@@ -1,4 +1,5 @@
 using Robust.Shared.GameStates;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
 namespace Content.Shared._MACRO.Popups.Components;
 
@@ -23,7 +24,7 @@ public sealed partial class IntervalPopupMessageStatusEffectComponent : PopupMes
     /// <summary>
     ///     The next time we should display a popup message.
     /// </summary>
-    [ViewVariables(VVAccess.ReadWrite)]
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer))]
     [AutoNetworkedField, AutoPausedField]
     public TimeSpan NextPopupTime = TimeSpan.Zero;
 }

--- a/Content.Shared/_MACRO/Popups/Components/IntervalPopupMessageStatusEffectComponent.cs
+++ b/Content.Shared/_MACRO/Popups/Components/IntervalPopupMessageStatusEffectComponent.cs
@@ -1,4 +1,4 @@
-namespace Content.Shared._DEN.StatusEffects.Components;
+namespace Content.Shared._MACRO.Popups.Components;
 
 /// <summary>
 ///     A status effect that will regularly create a popup message on the entity on a given interval.

--- a/Content.Shared/_MACRO/Popups/Components/PopupMessageStatusEffectComponent.cs
+++ b/Content.Shared/_MACRO/Popups/Components/PopupMessageStatusEffectComponent.cs
@@ -1,0 +1,39 @@
+using Content.Shared.EntityEffects.Effects.Transform;
+using Content.Shared.Popups;
+
+namespace Content.Shared._DEN.StatusEffects.Components;
+
+/// <summary>
+///     Abstract class for status effects that show popup messages.
+/// </summary>
+/// <remarks>
+///     This is very similar to the "PopupMessage" entity effect in metabolisms.
+/// </remarks>
+public abstract partial class PopupMessageStatusEffectComponent : Component
+{
+    /// <summary>
+    /// Array of messages that can popup.
+    /// Only one is chosen when the effect is applied.
+    /// </summary>
+    [DataField(required: true)]
+    public string[] Messages = default!;
+
+    /// <summary>
+    /// Whether to just the entity we're affecting, or everyone around them.
+    /// </summary>
+    [DataField]
+    public PopupRecipients Recipients = PopupRecipients.Local;
+
+    /// <summary>
+    /// Which popup API method to use.
+    /// Use PopupCoordinates in case the entity will be deleted while the popup is shown.
+    /// </summary>
+    [DataField]
+    public PopupMethod Method = PopupMethod.PopupEntity;
+
+    /// <summary>
+    /// Size of the popup.
+    /// </summary>
+    [DataField]
+    public PopupType VisualType = PopupType.Small;
+}

--- a/Content.Shared/_MACRO/Popups/Components/PopupMessageStatusEffectComponent.cs
+++ b/Content.Shared/_MACRO/Popups/Components/PopupMessageStatusEffectComponent.cs
@@ -36,4 +36,10 @@ public abstract partial class PopupMessageStatusEffectComponent : Component
     /// </summary>
     [DataField]
     public PopupType VisualType = PopupType.Small;
+
+    /// <summary>
+    /// The chance of this popup actually appearing.
+    /// </summary>
+    [DataField]
+    public float Chance = 1.0f;
 }

--- a/Content.Shared/_MACRO/Popups/Components/PopupMessageStatusEffectComponent.cs
+++ b/Content.Shared/_MACRO/Popups/Components/PopupMessageStatusEffectComponent.cs
@@ -1,7 +1,7 @@
 using Content.Shared.EntityEffects.Effects.Transform;
 using Content.Shared.Popups;
 
-namespace Content.Shared._DEN.StatusEffects.Components;
+namespace Content.Shared._MACRO.Popups.Components;
 
 /// <summary>
 ///     Abstract class for status effects that show popup messages.

--- a/Content.Shared/_MACRO/Popups/EntitySystems/PopupMessageStatusEffectSystem.cs
+++ b/Content.Shared/_MACRO/Popups/EntitySystems/PopupMessageStatusEffectSystem.cs
@@ -1,0 +1,86 @@
+using Content.Shared._DEN.StatusEffects.Components;
+using Content.Shared.EntityEffects.Effects.Transform;
+using Content.Shared.StatusEffectNew;
+using Content.Shared.StatusEffectNew.Components;
+using Robust.Shared.Random;
+using Robust.Shared.Timing;
+
+namespace Content.Shared._DEN.StatusEffects.EntitySystems;
+
+/// <summary>
+///     This system handles displaying popup messages for various popup message status effects.
+/// </summary>
+public sealed partial class PopupMessageStatusEffectSystem : EntitySystem
+{
+    [Dependency] private PopupMessageEntityEffectSystem _popupEffect = default!;
+    [Dependency] private IRobustRandom _random = default!;
+    [Dependency] private IGameTiming _timing = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<IntervalPopupMessageStatusEffectComponent, StatusEffectAppliedEvent>(OnIntervalPopupApplied);
+        SubscribeLocalEvent<ExpiryPopupMessageStatusEffectComponent, StatusEffectRemovedEvent>(OnExpiredPopupRemoved);
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        var query = EntityQueryEnumerator<IntervalPopupMessageStatusEffectComponent, StatusEffectComponent>();
+        while (query.MoveNext(out var uid, out var interval, out var statusEffect))
+        {
+            if (_timing.CurTime < interval.NextPopupTime)
+                continue;
+
+            UpdatePopupIntervalTime((uid, interval));
+            SpawnPopup((uid, statusEffect), interval);
+        }
+    }
+
+    private void OnIntervalPopupApplied(Entity<IntervalPopupMessageStatusEffectComponent> ent, ref StatusEffectAppliedEvent args)
+    {
+        UpdatePopupIntervalTime(ent);
+    }
+
+    private void OnExpiredPopupRemoved(Entity<ExpiryPopupMessageStatusEffectComponent> ent, ref StatusEffectRemovedEvent args)
+    {
+        SpawnPopup((ent.Owner, null), ent.Comp);
+    }
+
+    /// <summary>
+    ///     Spawns a popup message related to a popup message status effect.
+    /// </summary>
+    /// <param name="ent">The status effect entity.</param>
+    /// <param name="popupComp">The popup message component associated with this effect.</param>
+    private void SpawnPopup(Entity<StatusEffectComponent?> ent, PopupMessageStatusEffectComponent popupComp)
+    {
+        if (!Resolve(ent.Owner, ref ent.Comp))
+            return;
+
+        var statusEffect = ent.Comp;
+        if (statusEffect.AppliedTo == null)
+            return;
+
+        var xform = Transform(statusEffect.AppliedTo.Value);
+        _popupEffect.PopupMessage((statusEffect.AppliedTo.Value, xform),
+            popupComp.Messages,
+            popupComp.VisualType,
+            popupComp.Method,
+            popupComp.Recipients);
+    }
+
+    /// <summary>
+    ///     Sets the next popup message spawn time for an interval popup effect.
+    /// </summary>
+    /// <param name="ent">The interval popup status effect.</param>
+    private void UpdatePopupIntervalTime(Entity<IntervalPopupMessageStatusEffectComponent> ent)
+    {
+        var comp = ent.Comp;
+        var (min, max) = comp.Interval;
+        var newInterval = _random.NextDouble(min.TotalSeconds, max.TotalSeconds);
+
+        comp.NextPopupTime = _timing.CurTime + TimeSpan.FromSeconds(newInterval);
+    }
+}

--- a/Content.Shared/_MACRO/Popups/EntitySystems/PopupMessageStatusEffectSystem.cs
+++ b/Content.Shared/_MACRO/Popups/EntitySystems/PopupMessageStatusEffectSystem.cs
@@ -16,14 +16,6 @@ public sealed partial class PopupMessageStatusEffectSystem : EntitySystem
     [Dependency] private IRobustRandom _random = default!;
     [Dependency] private IGameTiming _timing = default!;
 
-    public override void Initialize()
-    {
-        base.Initialize();
-
-        SubscribeLocalEvent<IntervalPopupMessageStatusEffectComponent, StatusEffectAppliedEvent>(OnIntervalPopupApplied);
-        SubscribeLocalEvent<ExpiryPopupMessageStatusEffectComponent, StatusEffectRemovedEvent>(OnExpiredPopupRemoved);
-    }
-
     public override void Update(float frameTime)
     {
         base.Update(frameTime);
@@ -39,11 +31,13 @@ public sealed partial class PopupMessageStatusEffectSystem : EntitySystem
         }
     }
 
+    [SubscribeLocalEvent]
     private void OnIntervalPopupApplied(Entity<IntervalPopupMessageStatusEffectComponent> ent, ref StatusEffectAppliedEvent args)
     {
         UpdatePopupIntervalTime(ent);
     }
 
+    [SubscribeLocalEvent]
     private void OnExpiredPopupRemoved(Entity<ExpiryPopupMessageStatusEffectComponent> ent, ref StatusEffectRemovedEvent args)
     {
         SpawnPopup((ent.Owner, null), ent.Comp);

--- a/Content.Shared/_MACRO/Popups/EntitySystems/PopupMessageStatusEffectSystem.cs
+++ b/Content.Shared/_MACRO/Popups/EntitySystems/PopupMessageStatusEffectSystem.cs
@@ -1,5 +1,6 @@
 using Content.Shared._MACRO.Popups.Components;
 using Content.Shared.EntityEffects.Effects.Transform;
+using Content.Shared.Random.Helpers;
 using Content.Shared.StatusEffectNew;
 using Content.Shared.StatusEffectNew.Components;
 using Robust.Shared.Random;
@@ -13,7 +14,6 @@ namespace Content.Shared._MACRO.Popups.EntitySystems;
 public sealed partial class PopupMessageStatusEffectSystem : EntitySystem
 {
     [Dependency] private PopupMessageEntityEffectSystem _popupEffect = default!;
-    [Dependency] private IRobustRandom _random = default!;
     [Dependency] private IGameTiming _timing = default!;
 
     /// <summary>
@@ -73,7 +73,8 @@ public sealed partial class PopupMessageStatusEffectSystem : EntitySystem
     {
         var comp = ent.Comp;
         var (min, max) = comp.Interval;
-        var newInterval = _random.NextDouble(min.TotalSeconds, max.TotalSeconds);
+        var random = SharedRandomExtensions.PredictedRandom(_timing, GetNetEntity(ent));
+        var newInterval = random.NextDouble(min.TotalSeconds, max.TotalSeconds);
 
         comp.NextPopupTime = _timing.CurTime + TimeSpan.FromSeconds(newInterval);
         Dirty(ent);
@@ -86,9 +87,15 @@ public sealed partial class PopupMessageStatusEffectSystem : EntitySystem
     /// <param name="popupComp">The popup message component associated with this effect.</param>
     private void SpawnPopup(Entity<StatusEffectComponent?> ent, PopupMessageStatusEffectComponent popupComp)
     {
-        if (!Resolve(ent.Owner, ref ent.Comp))
+        if (!Resolve(ent.Owner, ref ent.Comp) || popupComp.Chance <= 0)
             return;
 
+        // Random chance to fail the popup.
+        var random = SharedRandomExtensions.PredictedRandom(_timing, GetNetEntity(ent));
+        if (popupComp.Chance < 1.0f && random.NextFloat() > popupComp.Chance)
+            return;
+
+        // Status effect must belong to an entity.
         var statusEffect = ent.Comp;
         if (statusEffect.AppliedTo == null)
             return;

--- a/Content.Shared/_MACRO/Popups/EntitySystems/PopupMessageStatusEffectSystem.cs
+++ b/Content.Shared/_MACRO/Popups/EntitySystems/PopupMessageStatusEffectSystem.cs
@@ -63,8 +63,7 @@ public sealed partial class PopupMessageStatusEffectSystem : EntitySystem
         if (statusEffect.AppliedTo == null)
             return;
 
-        var xform = Transform(statusEffect.AppliedTo.Value);
-        _popupEffect.PopupMessage((statusEffect.AppliedTo.Value, xform),
+        _popupEffect.PopupMessage(statusEffect.AppliedTo.Value,
             popupComp.Messages,
             popupComp.VisualType,
             popupComp.Method,

--- a/Content.Shared/_MACRO/Popups/EntitySystems/PopupMessageStatusEffectSystem.cs
+++ b/Content.Shared/_MACRO/Popups/EntitySystems/PopupMessageStatusEffectSystem.cs
@@ -1,11 +1,11 @@
-using Content.Shared._DEN.StatusEffects.Components;
+using Content.Shared._MACRO.Popups.Components;
 using Content.Shared.EntityEffects.Effects.Transform;
 using Content.Shared.StatusEffectNew;
 using Content.Shared.StatusEffectNew.Components;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
 
-namespace Content.Shared._DEN.StatusEffects.EntitySystems;
+namespace Content.Shared._MACRO.Popups.EntitySystems;
 
 /// <summary>
 ///     This system handles displaying popup messages for various popup message status effects.

--- a/Content.Shared/_MACRO/Popups/EntitySystems/PopupMessageStatusEffectSystem.cs
+++ b/Content.Shared/_MACRO/Popups/EntitySystems/PopupMessageStatusEffectSystem.cs
@@ -81,5 +81,6 @@ public sealed partial class PopupMessageStatusEffectSystem : EntitySystem
         var newInterval = _random.NextDouble(min.TotalSeconds, max.TotalSeconds);
 
         comp.NextPopupTime = _timing.CurTime + TimeSpan.FromSeconds(newInterval);
+        Dirty(ent);
     }
 }

--- a/Content.Shared/_MACRO/Popups/EntitySystems/PopupMessageStatusEffectSystem.cs
+++ b/Content.Shared/_MACRO/Popups/EntitySystems/PopupMessageStatusEffectSystem.cs
@@ -16,6 +16,10 @@ public sealed partial class PopupMessageStatusEffectSystem : EntitySystem
     [Dependency] private IRobustRandom _random = default!;
     [Dependency] private IGameTiming _timing = default!;
 
+    /// <summary>
+    ///     Checks status effects that may need to trigger a popup on a given interval.
+    /// </summary>
+    /// <inheritdoc />
     public override void Update(float frameTime)
     {
         base.Update(frameTime);
@@ -31,12 +35,20 @@ public sealed partial class PopupMessageStatusEffectSystem : EntitySystem
         }
     }
 
+    /// <summary>
+    ///     Initializes the first popup interval when this status effect is added.
+    /// </summary>
+    /// <param name="ent">The interval popup status effect.</param>
     [SubscribeLocalEvent]
     private void OnIntervalPopupApplied(Entity<IntervalPopupMessageStatusEffectComponent> ent, ref StatusEffectAppliedEvent args)
     {
         UpdatePopupIntervalTime(ent);
     }
 
+    /// <summary>
+    ///     Spawns a popup when this status effect is removed.
+    /// </summary>
+    /// <param name="ent">The expiry popup status effect.</param>
     [SubscribeLocalEvent]
     private void OnExpiredPopupRemoved(Entity<ExpiryPopupMessageStatusEffectComponent> ent, ref StatusEffectRemovedEvent args)
     {

--- a/Content.Shared/_MACRO/Popups/EntitySystems/PopupMessageStatusEffectSystem.cs
+++ b/Content.Shared/_MACRO/Popups/EntitySystems/PopupMessageStatusEffectSystem.cs
@@ -36,6 +36,26 @@ public sealed partial class PopupMessageStatusEffectSystem : EntitySystem
     }
 
     /// <summary>
+    ///     Spawns a popup when this status effect is applied.
+    /// </summary>
+    /// <param name="ent">The initial popup status effect.</param>
+    [SubscribeLocalEvent]
+    private void OnInitialPopupApplied(Entity<InitialPopupMessageStatusEffectComponent> ent, ref StatusEffectAppliedEvent args)
+    {
+        SpawnPopup(ent.Owner, ent.Comp);
+    }
+
+    /// <summary>
+    ///     Spawns a popup when this status effect is removed.
+    /// </summary>
+    /// <param name="ent">The expiry popup status effect.</param>
+    [SubscribeLocalEvent]
+    private void OnExpiredPopupRemoved(Entity<ExpiryPopupMessageStatusEffectComponent> ent, ref StatusEffectRemovedEvent args)
+    {
+        SpawnPopup(ent.Owner, ent.Comp);
+    }
+
+    /// <summary>
     ///     Initializes the first popup interval when this status effect is added.
     /// </summary>
     /// <param name="ent">The interval popup status effect.</param>
@@ -46,13 +66,17 @@ public sealed partial class PopupMessageStatusEffectSystem : EntitySystem
     }
 
     /// <summary>
-    ///     Spawns a popup when this status effect is removed.
+    ///     Sets the next popup message spawn time for an interval popup effect.
     /// </summary>
-    /// <param name="ent">The expiry popup status effect.</param>
-    [SubscribeLocalEvent]
-    private void OnExpiredPopupRemoved(Entity<ExpiryPopupMessageStatusEffectComponent> ent, ref StatusEffectRemovedEvent args)
+    /// <param name="ent">The interval popup status effect.</param>
+    private void UpdatePopupIntervalTime(Entity<IntervalPopupMessageStatusEffectComponent> ent)
     {
-        SpawnPopup((ent.Owner, null), ent.Comp);
+        var comp = ent.Comp;
+        var (min, max) = comp.Interval;
+        var newInterval = _random.NextDouble(min.TotalSeconds, max.TotalSeconds);
+
+        comp.NextPopupTime = _timing.CurTime + TimeSpan.FromSeconds(newInterval);
+        Dirty(ent);
     }
 
     /// <summary>
@@ -74,19 +98,5 @@ public sealed partial class PopupMessageStatusEffectSystem : EntitySystem
             popupComp.VisualType,
             popupComp.Method,
             popupComp.Recipients);
-    }
-
-    /// <summary>
-    ///     Sets the next popup message spawn time for an interval popup effect.
-    /// </summary>
-    /// <param name="ent">The interval popup status effect.</param>
-    private void UpdatePopupIntervalTime(Entity<IntervalPopupMessageStatusEffectComponent> ent)
-    {
-        var comp = ent.Comp;
-        var (min, max) = comp.Interval;
-        var newInterval = _random.NextDouble(min.TotalSeconds, max.TotalSeconds);
-
-        comp.NextPopupTime = _timing.CurTime + TimeSpan.FromSeconds(newInterval);
-        Dirty(ent);
     }
 }

--- a/Resources/Locale/en-US/_MACRO/guidebook/entity-effects/conditions.ftl
+++ b/Resources/Locale/en-US/_MACRO/guidebook/entity-effects/conditions.ftl
@@ -1,8 +1,16 @@
+entity-condition-guidebook-status-effect-duration-min =
+    the target has at least {NATURALFIXED($min, 3)} {MANY("second", $min)} of {$effect}
+entity-condition-guidebook-status-effect-duration-max =
+    the target has at most {NATURALFIXED($max, 3)} {MANY("second", $max)} of {$effect}
+entity-condition-guidebook-status-effect-duration-minmax =
+    the target has between {NATURALFIXED($min, 3)} and {NATURALFIXED($max, 3)} {MANY("second", $max)} of {$effect}
+
 entity-condition-guidebook-status-effect-duration =
     { $max ->
-        [2147483648] the target has at least {NATURALFIXED($min, 3)} {MANY("second", $min)} of {$effect}
-        *[other] { $min ->
-                    [0] the target has at most {NATURALFIXED($max, 3)} {MANY("second", $max)} of {$effect}
-                    *[other] the target has between {NATURALFIXED($min, 3)} and {NATURALFIXED($max, 3)} {MANY("second", $max)} of {$effect}
-                 }
+        [2147483648] {entity-condition-guidebook-status-effect-duration-min}
+        *[other]
+        { $min ->
+            [0] {entity-condition-guidebook-status-effect-duration-max}
+            *[other] {entity-condition-guidebook-status-effect-duration-minmax}
+        }
     }

--- a/Resources/Locale/en-US/_MACRO/guidebook/entity-effects/conditions.ftl
+++ b/Resources/Locale/en-US/_MACRO/guidebook/entity-effects/conditions.ftl
@@ -1,0 +1,8 @@
+entity-condition-guidebook-status-effect-duration =
+    { $max ->
+        [2147483648] the target has at least {NATURALFIXED($min, 3)} {MANY("second", $min)} of {$effect}
+        *[other] { $min ->
+                    [0] the target has at most {NATURALFIXED($max, 3)} {MANY("second", $max)} of {$effect}
+                    *[other] the target has between {NATURALFIXED($min, 3)} and {NATURALFIXED($max, 3)} {MANY("second", $max)} of {$effect}
+                 }
+    }

--- a/Resources/Locale/en-US/_MACRO/guidebook/guides.ftl
+++ b/Resources/Locale/en-US/_MACRO/guidebook/guides.ftl
@@ -1,0 +1,1 @@
+guide-entry-debug-chemicals = Debug Chemicals

--- a/Resources/Locale/en-US/_MACRO/reagents/meta/debug.ftl
+++ b/Resources/Locale/en-US/_MACRO/reagents/meta/debug.ftl
@@ -1,0 +1,2 @@
+reagent-name-debug-popups = debug popup effect
+reagent-desc-debug-popups = A reagent that demonstrates status effect popups and requirements.

--- a/Resources/Locale/en-US/_MACRO/status-effects/popups/debug.ftl
+++ b/Resources/Locale/en-US/_MACRO/status-effects/popups/debug.ftl
@@ -1,0 +1,5 @@
+status-effect-debug-popups-initial1 = I'm just getting started!
+status-effect-debug-popups-interval1 = Here it comes!
+status-effect-debug-popups-interval2 = It's coming up!
+status-effect-debug-popups-interval3 = Keep going!
+status-effect-debug-popups-expired1 = I'm done.

--- a/Resources/Prototypes/_MACRO/Guidebook/debug.yml
+++ b/Resources/Prototypes/_MACRO/Guidebook/debug.yml
@@ -1,5 +1,7 @@
-- type: guideEntry
-  id: DebugChemicals
-  name: guide-entry-debug-chemicals
-  text: "/ServerInfo/_MACRO/Guidebook/ChemicalTabs/Debug.xml"
-  filterEnabled: True
+# theyre making guidebooks for developers look at them here
+
+# - type: guideEntry
+#   id: DebugChemicals
+#   name: guide-entry-debug-chemicals
+#   text: "/ServerInfo/_MACRO/Guidebook/ChemicalTabs/Debug.xml"
+#   filterEnabled: True

--- a/Resources/Prototypes/_MACRO/Guidebook/debug.yml
+++ b/Resources/Prototypes/_MACRO/Guidebook/debug.yml
@@ -1,0 +1,5 @@
+- type: guideEntry
+  id: DebugChemicals
+  name: guide-entry-debug-chemicals
+  text: "/ServerInfo/_MACRO/Guidebook/ChemicalTabs/Debug.xml"
+  filterEnabled: True

--- a/Resources/Prototypes/_MACRO/Reagents/debug.yml
+++ b/Resources/Prototypes/_MACRO/Reagents/debug.yml
@@ -1,0 +1,51 @@
+- type: entity
+  parent: StatusEffectBase
+  id: DebugStatusEffectPopups
+  name: debug popups effect
+  description: Debug status effect for the sake of demonstrating popup components.
+  suffix: DEBUG
+  components:
+  # Spawns a popup message on startup.
+  - type: InitialPopupMessageStatusEffect
+    recipients: Local
+    visualType: Medium
+    messages: [ status-effect-debug-popups-initial1 ]
+  # Spawns a popup message with 80% chance every 1-4 seconds.
+  # Chooses one of three random messages.
+  - type: IntervalPopupMessageStatusEffect
+    recipients: Local
+    chance: 0.8
+    interval: [1, 4]
+    messages:
+    - status-effect-debug-popups-interval1
+    - status-effect-debug-popups-interval2
+    - status-effect-debug-popups-interval3
+  # Spawns a popup message when this expires.
+  - type: ExpiryPopupMessageStatusEffect
+    recipients: Local
+    visualType: MediumCaution
+    messages: [ status-effect-debug-popups-expired1 ]
+
+- type: reagent
+  id: DebugPopupEffect
+  group: Debug
+  name: reagent-name-debug-popups
+  desc: reagent-desc-debug-popups
+  physicalDesc: reagent-physical-desc-nothing
+  metabolisms:
+    Digestion:
+      metabolismRate: 0.5
+      metabolites:
+        DebugPopupEffect: 1.0
+    Metabolites:
+      effects:
+      - !type:ModifyStatusEffect
+        effectProto: DebugStatusEffectPopups
+        type: Add
+        time: 5
+        conditions:
+        # This effectively caps the status effect's duration at 15 seconds (active metabolism
+        # notwithstanding), as it can only add time if this is less than 10 seconds.
+        - !type:StatusEffectDurationCondition
+          effectProto: DebugStatusEffectPopups
+          max: 10

--- a/Resources/Prototypes/_MACRO/Reagents/debug.yml
+++ b/Resources/Prototypes/_MACRO/Reagents/debug.yml
@@ -23,7 +23,7 @@
   # Spawns a popup message when this expires.
   - type: ExpiryPopupMessageStatusEffect
     recipients: Local
-    visualType: MediumCaution
+    visualType: LargeCaution
     messages: [ status-effect-debug-popups-expired1 ]
 
 - type: reagent
@@ -33,7 +33,11 @@
   desc: reagent-desc-debug-popups
   physicalDesc: reagent-physical-desc-nothing
   metabolisms:
-    Digestion:
+    Digestion: # Hack to get around slow transfer rates.
+      metabolismRate: 0.5
+      metabolites:
+        DebugPopupEffect: 1.0
+    Bloodstream: # Hack to get around slow transfer rates.
       metabolismRate: 0.5
       metabolites:
         DebugPopupEffect: 1.0
@@ -49,3 +53,13 @@
         - !type:StatusEffectDurationCondition
           effectProto: DebugStatusEffectPopups
           max: 10
+      - !type:ModifyStatusEffect
+        effectProto: StatusEffectSeeingRainbow
+        type: Add
+        time: 2
+        conditions:
+        # Requires another status effect between a range of durations to take effect.
+        - !type:StatusEffectDurationCondition
+          effectProto: StatusEffectDrunk
+          min: 30
+          max: 300

--- a/Resources/ServerInfo/_MACRO/Guidebook/ChemicalTabs/Debug.xml
+++ b/Resources/ServerInfo/_MACRO/Guidebook/ChemicalTabs/Debug.xml
@@ -1,0 +1,9 @@
+<Document>
+
+# Debug
+
+These reagents are for development and administrative use only. Unless you're a developer, you should not see this guidebook entry!
+
+<GuideReagentGroupEmbed Group="Debug"/>
+
+</Document>


### PR DESCRIPTION
## About the PR
This PR adds components that allows developers to design status effects with popup messages.
It also adds an EntityCondition for checking that the duration of a certain status effect is within a certain range.

### How to enable / disable
The components and conditional have no gameplay impact unless specifically implemented, and can be safely ignored.

Sample YML prototypes have been provided at `Resources/Prototypes/_MACRO/Reagents/debug.yml` to demonstrate using the components and entity condition. It uses very similar parameters to `PopupMessage` for reagents.

## Why / Balance
The status effect popup messages are a much more consistent solution to reagent metabolisms' `PopupMessage`, allowing you to control the circumstances and frequency of popup message effects more granularly. This is useful for "roleplay chemicals" that center around "psychological effects" as well as overdose warnings, in particular.

The status effect entity condition is primarily designed to put a cap on the duration of reagent-based status effects, but it can be used to design medicinal interactions and the like, as well.

## Technical details

I moved the popup message effect logic used for reagent `PopupMesssage` effects into a public function in `PopupMessageEntityEffectSystem`.

Added a new EntityCondition, `StatusEffectDurationCondition`, and its respective entity system. This is used to restrict entity effects based on having a certain other status effect within a certain range.

`PopupMessageStatusEffectComponent` is an abstract component containing common fields related to spawning popup messages. These are implemented in three status effect components, for Initial (startup), Interval (min/max duration), and Expiry respectively. They use the new public method for popup messages to handle their logic.

A new, unobtainable "debug" status effect and reagent was added to `Resources/Prototypes/_MACRO/Reagents/debug.yml` to demonstrate the effects of the status effect in question.

For debugger convenience, I included a "Debug" chemical guidebook entry at `Resources/Prototypes/_MACRO/Guidebook/debug.yml` so that you can view the guidebook metabolism effects of the debug popup reagent.

## Test plan

Try uncommenting the "Debug Chemicals" guidebook entry and viewing the effects of the debug popup message.

Add the reagent `DebugPopupEffect` to your metabolites, one way or another. When metabolized, this reagent will add a status effect to you that will display a popup message on startup, every 1-4 seconds (with an 80% chance), and when it expires.

If your character has between 30 and 300 seconds of drunkenness while metabolizing `DebugPopupEffect`, you will start seeing rainbows (weed high filter).

## Media

https://github.com/user-attachments/assets/2e8a1cc2-cc56-4cb5-bcfc-ed1a2229485e

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the Macrocosm [Pull Request Conventions](https://docs.macrocosm.cool/docs/Conventions/pull-requests/).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

Message popup logic for the `PopupMessage` reagent effect has been moved to a public function in `Content.Shared/_MACRO/EntityEffects/Effects/Transform/PopupMessageEntityEffectSystem.cs`; if/when the logic of the original function changes, anticipate a merge conflict.

## Changelog
Not player-facing.