### PR TITLE
refactor: add parents to all floor sign and pathfind decals

### DIFF
--- a/Resources/Prototypes/_MACRO/Decals/floor_signs.yml
+++ b/Resources/Prototypes/_MACRO/Decals/floor_signs.yml
@@ -1,435 +1,508 @@
+# Helper prototype for applying properties to all floor signs (e.g. tags).
 - type: decal
+  abstract: true
+  id: BaseFloorSign
+
+- type: decal
+  parent: BaseFloorSign
   id: FloorSignAI
   sprite:
     sprite: _MACRO/Decals/floor_signs.rsi
     state: ai
 
 - type: decal
+  parent: BaseFloorSign
   id: FloorSignAnchor
   sprite:
     sprite: _MACRO/Decals/floor_signs.rsi
     state: anchor
 
 - type: decal
+  parent: BaseFloorSign
   id: FloorSignAnomalyLab
   sprite:
     sprite: _MACRO/Decals/floor_signs.rsi
     state: anomlab
 
 - type: decal
+  parent: BaseFloorSign
   id: FloorSignArcade
   sprite:
     sprite: _MACRO/Decals/floor_signs.rsi
     state: arcade
 
 - type: decal
+  parent: BaseFloorSign
   id: FloorSignArmory
   sprite:
     sprite: _MACRO/Decals/floor_signs.rsi
     state: armory
 
 - type: decal
+  parent: BaseFloorSign
   id: FloorSignArrivals
   sprite:
     sprite: _MACRO/Decals/floor_signs.rsi
     state: arrivals
 
 - type: decal
+  parent: BaseFloorSign
   id: FloorSignAtmos
   sprite:
     sprite: _MACRO/Decals/floor_signs.rsi
     state: atmos
 
 - type: decal
+  parent: BaseFloorSign
   id: FloorSignBar
   sprite:
     sprite: _MACRO/Decals/floor_signs.rsi
     state: bar
 
 - type: decal
+  parent: BaseFloorSign
   id: FloorSignBotany
   sprite:
     sprite: _MACRO/Decals/floor_signs.rsi
     state: botany
 
 - type: decal
+  parent: BaseFloorSign
   id: FloorSignBridge
   sprite:
     sprite: _MACRO/Decals/floor_signs.rsi
     state: bridge
 
 - type: decal
+  parent: BaseFloorSign
   id: FloorSignBriefing
   sprite:
     sprite: _MACRO/Decals/floor_signs.rsi
     state: briefing
 
 - type: decal
+  parent: BaseFloorSign
   id: FloorSignBrig
   sprite:
     sprite: _MACRO/Decals/floor_signs.rsi
     state: brig
 
 - type: decal
+  parent: BaseFloorSign
   id: FloorSignCargo
   sprite:
     sprite: _MACRO/Decals/floor_signs.rsi
     state: cargo
 
 - type: decal
+  parent: BaseFloorSign
   id: FloorSignCCOffice
   sprite:
     sprite: _MACRO/Decals/floor_signs.rsi
     state: cco
 
 - type: decal
+  parent: BaseFloorSign
   id: FloorSignChapel
   sprite:
     sprite: _MACRO/Decals/floor_signs.rsi
     state: chapel
 
 - type: decal
+  parent: BaseFloorSign
   id: FloorSignChem
   sprite:
     sprite: _MACRO/Decals/floor_signs.rsi
     state: chem
 
 - type: decal
+  parent: BaseFloorSign
   id: FloorSignClown
   sprite:
     sprite: _MACRO/Decals/floor_signs.rsi
     state: clown
 
 - type: decal
+  parent: BaseFloorSign
   id: FloorSignComms
   sprite:
     sprite: _MACRO/Decals/floor_signs.rsi
     state: comms
 
 - type: decal
+  parent: BaseFloorSign
   id: FloorSignCourtroom
   sprite:
     sprite: _MACRO/Decals/floor_signs.rsi
     state: court
 
 - type: decal
+  parent: BaseFloorSign
   id: FloorSignCryogenics
   sprite:
     sprite: _MACRO/Decals/floor_signs.rsi
     state: cryogenics
 
 - type: decal
+  parent: BaseFloorSign
   id: FloorSignCryosleep
   sprite:
     sprite: _MACRO/Decals/floor_signs.rsi
     state: cryosleep
 
 - type: decal
+  parent: BaseFloorSign
   id: FloorSignDetective
   sprite:
     sprite: _MACRO/Decals/floor_signs.rsi
     state: det
 
 - type: decal
+  parent: BaseFloorSign
   id: FloorSignDisposals
   sprite:
     sprite: _MACRO/Decals/floor_signs.rsi
     state: disposals
 
 - type: decal
+  parent: BaseFloorSign
   id: FloorSignDorms
   sprite:
     sprite: _MACRO/Decals/floor_signs.rsi
     state: dorms
 
 - type: decal
+  parent: BaseFloorSign
   id: FloorSignEngi
   sprite:
     sprite: _MACRO/Decals/floor_signs.rsi
     state: engi
 
 - type: decal
+  parent: BaseFloorSign
   id: FloorSignEVA
   sprite:
     sprite: _MACRO/Decals/floor_signs.rsi
     state: eva
 
 - type: decal
+  parent: BaseFloorSign
   id: FloorSignEvac
   sprite:
     sprite: _MACRO/Decals/floor_signs.rsi
     state: evac
 
 - type: decal
+  parent: BaseFloorSign
   id: FloorSignGenetics
   sprite:
     sprite: _MACRO/Decals/floor_signs.rsi
     state: genetics
 
 - type: decal
+  parent: BaseFloorSign
   id: FloorSignGrav
   sprite:
     sprite: _MACRO/Decals/floor_signs.rsi
     state: grav
 
 - type: decal
+  parent: BaseFloorSign
   id: FloorSignHOP
   sprite:
     sprite: _MACRO/Decals/floor_signs.rsi
     state: hop
 
 - type: decal
+  parent: BaseFloorSign
   id: FloorSignIA
   sprite:
     sprite: _MACRO/Decals/floor_signs.rsi
     state: ia
 
 - type: decal
+  parent: BaseFloorSign
   id: FloorSignInterrogation
   sprite:
     sprite: _MACRO/Decals/floor_signs.rsi
     state: inter
 
 - type: decal
+  parent: BaseFloorSign
   id: FloorSignJani
   sprite:
     sprite: _MACRO/Decals/floor_signs.rsi
     state: jani
 
 - type: decal
+  parent: BaseFloorSign
   id: FloorSignKitchen
   sprite:
     sprite: _MACRO/Decals/floor_signs.rsi
     state: kitchen
 
 - type: decal
+  parent: BaseFloorSign
   id: FloorSignLawyer
   sprite:
     sprite: _MACRO/Decals/floor_signs.rsi
     state: law
 
 - type: decal
+  parent: BaseFloorSign
   id: FloorSignLibrary
   sprite:
     sprite: _MACRO/Decals/floor_signs.rsi
     state: library
 
 - type: decal
+  parent: BaseFloorSign
   id: FloorSignMagi
   sprite:
     sprite: _MACRO/Decals/floor_signs.rsi
     state: magi
 
 - type: decal
+  parent: BaseFloorSign
   id: FloorSignMail
   sprite:
     sprite: _MACRO/Decals/floor_signs.rsi
     state: mail
 
 - type: decal
+  parent: BaseFloorSign
   id: FloorSignMats
   sprite:
     sprite: _MACRO/Decals/floor_signs.rsi
     state: mats
 
 - type: decal
+  parent: BaseFloorSign
   id: FloorSignMedical
   sprite:
     sprite: _MACRO/Decals/floor_signs.rsi
     state: med
 
 - type: decal
+  parent: BaseFloorSign
   id: FloorSignMime
   sprite:
     sprite: _MACRO/Decals/floor_signs.rsi
     state: mime
 
 - type: decal
+  parent: BaseFloorSign
   id: FloorSignMorgue
   sprite:
     sprite: _MACRO/Decals/floor_signs.rsi
     state: morgue
 
 - type: decal
+  parent: BaseFloorSign
   id: FloorSignMusician
   sprite:
     sprite: _MACRO/Decals/floor_signs.rsi
     state: musician
 
 - type: decal
+  parent: BaseFloorSign
   id: FloorSignNewsroom
   sprite:
     sprite: _MACRO/Decals/floor_signs.rsi
     state: news
 
 - type: decal
+  parent: BaseFloorSign
   id: FloorSignOrdnanceLab
   sprite:
     sprite: _MACRO/Decals/floor_signs.rsi
     state: ordnance
 
 - type: decal
+  parent: BaseFloorSign
   id: FloorSignPointer
   sprite:
     sprite: _MACRO/Decals/floor_signs.rsi
     state: pointer
 
 - type: decal
+  parent: BaseFloorSign
   id: FloorSignPower
   sprite:
     sprite: _MACRO/Decals/floor_signs.rsi
     state: power
 
 - type: decal
+  parent: BaseFloorSign
   id: FloorSignPsych
   sprite:
     sprite: _MACRO/Decals/floor_signs.rsi
     state: psych
 
 - type: decal
+  parent: BaseFloorSign
   id: FloorSignReactor
   sprite:
     sprite: _MACRO/Decals/floor_signs.rsi
     state: reactor
 
 - type: decal
+  parent: BaseFloorSign
   id: FloorSignRobo
   sprite:
     sprite: _MACRO/Decals/floor_signs.rsi
     state: robo
 
 - type: decal
+  parent: BaseFloorSign
   id: FloorSignSalvage
   sprite:
     sprite: _MACRO/Decals/floor_signs.rsi
     state: salvage
 
 - type: decal
+  parent: BaseFloorSign
   id: FloorSignSatelliteArray
   sprite:
     sprite: _MACRO/Decals/floor_signs.rsi
     state: satellite
 
 - type: decal
+  parent: BaseFloorSign
   id: FloorSignScience
   sprite:
     sprite: _MACRO/Decals/floor_signs.rsi
     state: sci
 
 - type: decal
+  parent: BaseFloorSign
   id: FloorSignSecurity
   sprite:
     sprite: _MACRO/Decals/floor_signs.rsi
     state: security
 
 - type: decal
+  parent: BaseFloorSign
   id: FloorSignService
   sprite:
     sprite: _MACRO/Decals/floor_signs.rsi
     state: service
 
 - type: decal
+  parent: BaseFloorSign
   id: FloorSignSingularity
   sprite:
     sprite: _MACRO/Decals/floor_signs.rsi
     state: singularity
 
 - type: decal
+  parent: BaseFloorSign
   id: FloorSignSolars
   sprite:
     sprite: _MACRO/Decals/floor_signs.rsi
     state: solars
 
 - type: decal
+  parent: BaseFloorSign
   id: FloorSignSupermatter
   sprite:
     sprite: _MACRO/Decals/floor_signs.rsi
     state: spicyrock
 
 - type: decal
+  parent: BaseFloorSign
   id: FloorSignSurgery
   sprite:
     sprite: _MACRO/Decals/floor_signs.rsi
     state: surgery
 
 - type: decal
+  parent: BaseFloorSign
   id: FloorSignTechStorage
   sprite:
     sprite: _MACRO/Decals/floor_signs.rsi
     state: tech
 
 - type: decal
+  parent: BaseFloorSign
   id: FloorSignTEG
   sprite:
     sprite: _MACRO/Decals/floor_signs.rsi
     state: teg
 
 - type: decal
+  parent: BaseFloorSign
   id: FloorSignTelescience
   sprite:
     sprite: _MACRO/Decals/floor_signs.rsi
     state: telesci
 
 - type: decal
+  parent: BaseFloorSign
   id: FloorSignTesla
   sprite:
     sprite: _MACRO/Decals/floor_signs.rsi
     state: tesla
 
 - type: decal
+  parent: BaseFloorSign
   id: FloorSignTheater
   sprite:
     sprite: _MACRO/Decals/floor_signs.rsi
     state: theater
 
 - type: decal
+  parent: BaseFloorSign
   id: FloorSignTools
   sprite:
     sprite: _MACRO/Decals/floor_signs.rsi
     state: tools
 
 - type: decal
+  parent: BaseFloorSign
   id: FloorSignWarden
   sprite:
     sprite: _MACRO/Decals/floor_signs.rsi
     state: warden
 
 - type: decal
+  parent: BaseFloorSign
   id: FloorSignVault
   sprite:
     sprite: _MACRO/Decals/floor_signs.rsi
     state: vault
 
 - type: decal
+  parent: BaseFloorSign
   id: FloorSignViro
   sprite:
     sprite: _MACRO/Decals/floor_signs.rsi
     state: viro
 
 - type: decal
+  parent: BaseFloorSign
   id: FloorSignVoxBox
   sprite:
     sprite: _MACRO/Decals/floor_signs.rsi
     state: voxbox
 
 - type: decal
+  parent: BaseFloorSign
   id: FloorSignXenoarch
   sprite:
     sprite: _MACRO/Decals/floor_signs.rsi
     state: xenoarch
 
 - type: decal
+  parent: BaseFloorSign
   id: FloorSignXenobio
   sprite:
     sprite: _MACRO/Decals/floor_signs.rsi
     state: xenobio
 
 - type: decal
+  parent: BaseFloorSign
   id: FloorSignZoo
   sprite:
     sprite: _MACRO/Decals/floor_signs.rsi
     state: zoo
-
-
-
-

--- a/Resources/Prototypes/_MACRO/Decals/pathfind.yml
+++ b/Resources/Prototypes/_MACRO/Decals/pathfind.yml
@@ -1,72 +1,124 @@
+# Helper prototype for applying properties to all pathfinding markings (e.g. tags).
+- type: decal
+  abstract: true
+  id: BasePathfind
+
+- type: decal
+  abstract: true
+  parent: BasePathfind
+  id: BasePathfindEnd
+
+- type: decal
+  abstract: true
+  parent: BasePathfind
+  id: BasePathfindBlockFlat
+
+- type: decal
+  abstract: true
+  parent: BasePathfind
+  id: BasePathfindBlockChevron
+
+- type: decal
+  abstract: true
+  parent: BasePathfind
+  id: BasePathfindFillChevron
+
+- type: decal
+  abstract: true
+  parent: BasePathfind
+  id: BasePathfindSymbolContainer
+
+- type: decal
+  abstract: true
+  parent: BasePathfind
+  id: BasePathfindYield
+
+- type: decal
+  abstract: true
+  parent: BasePathfind
+  id: BasePathfindPrefab
+
 # end pieces
 
 - type: decal
+  parent: BasePathfindEnd
   id: PathfindEndTopLeft
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: endtopleft
 
 - type: decal
+  parent: BasePathfindEnd
   id: PathfindEndTopCenter
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: endtopcenter
 
 - type: decal
+  parent: BasePathfindEnd
   id: PathfindEndTopRight
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: endtopright
 
 - type: decal
+  parent: BasePathfindEnd
   id: PathfindEndLeftTop
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: endlefttop
 
 - type: decal
+  parent: BasePathfindEnd
   id: PathfindEndLeftCenter
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: endleftcenter
 
 - type: decal
+  parent: BasePathfindEnd
   id: PathfindEndLeftBottom
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: endleftbottom
 
 - type: decal
+  parent: BasePathfindEnd
   id: PathfindEndRightTop
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: endrighttop
 
 - type: decal
+  parent: BasePathfindEnd
   id: PathfindEndRightCenter
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: endrightcenter
 
 - type: decal
+  parent: BasePathfindEnd
   id: PathfindEndRightBottom
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: endrightbottom
 
 - type: decal
+  parent: BasePathfindEnd
   id: PathfindEndBottomLeft
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: endbottomleft
 
 - type: decal
+  parent: BasePathfindEnd
   id: PathfindEndBottomCenter
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: endbottomcenter
 
 - type: decal
+  parent: BasePathfindEnd
   id: PathfindEndBottomRight
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
@@ -75,54 +127,63 @@
 # flat blocks
 
 - type: decal
+  parent: BasePathfindBlockFlat
   id: PathfindBlockNW
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: blocknw
 
 - type: decal
+  parent: BasePathfindBlockFlat
   id: PathfindBlockN
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: blockn
 
 - type: decal
+  parent: BasePathfindBlockFlat
   id: PathfindBlockNE
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: blockne
 
 - type: decal
+  parent: BasePathfindBlockFlat
   id: PathfindBlockW
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: blockw
 
 - type: decal
+  parent: BasePathfindBlockFlat
   id: PathfindBlockC
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: blockc
 
 - type: decal
+  parent: BasePathfindBlockFlat
   id: PathfindBlockE
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: blocke
 
 - type: decal
+  parent: BasePathfindBlockFlat
   id: PathfindBlockSW
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: blocksw
 
 - type: decal
+  parent: BasePathfindBlockFlat
   id: PathfindBlockS
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: blocks
 
 - type: decal
+  parent: BasePathfindBlockFlat
   id: PathfindBlockSE
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
@@ -131,216 +192,252 @@
 # chevron blocks
 
 - type: decal
+  parent: BasePathfindBlockChevron
   id: PathfindBlockNWChevronN
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: blocknwchevn
 
 - type: decal
+  parent: BasePathfindBlockChevron
   id: PathfindBlockNWChevronW
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: blocknwchevw
 
 - type: decal
+  parent: BasePathfindBlockChevron
   id: PathfindBlockNWChevronE
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: blocknwcheve
 
 - type: decal
+  parent: BasePathfindBlockChevron
   id: PathfindBlockNWChevronS
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: blocknwchevs
 
 - type: decal
+  parent: BasePathfindBlockChevron
   id: PathfindBlockNChevronN
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: blocknchevn
 
 - type: decal
+  parent: BasePathfindBlockChevron
   id: PathfindBlockNChevronW
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: blocknchevw
 
 - type: decal
+  parent: BasePathfindBlockChevron
   id: PathfindBlockNChevronE
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: blockncheve
 
 - type: decal
+  parent: BasePathfindBlockChevron
   id: PathfindBlockNChevronS
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: blocknchevs
 
 - type: decal
+  parent: BasePathfindBlockChevron
   id: PathfindBlockNEChevronN
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: blocknechevn
 
 - type: decal
+  parent: BasePathfindBlockChevron
   id: PathfindBlockNEChevronW
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: blocknechevw
 
 - type: decal
+  parent: BasePathfindBlockChevron
   id: PathfindBlockNEChevronE
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: blocknecheve
 
 - type: decal
+  parent: BasePathfindBlockChevron
   id: PathfindBlockNEChevronS
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: blocknechevs
 
 - type: decal
+  parent: BasePathfindBlockChevron
   id: PathfindBlockWChevronN
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: blockwchevn
 
 - type: decal
+  parent: BasePathfindBlockChevron
   id: PathfindBlockWChevronW
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: blockwchevw
 
 - type: decal
+  parent: BasePathfindBlockChevron
   id: PathfindBlockWChevronE
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: blockwcheve
 
 - type: decal
+  parent: BasePathfindBlockChevron
   id: PathfindBlockWChevronS
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: blockwchevs
 
 - type: decal
+  parent: BasePathfindBlockChevron
   id: PathfindBlockCChevronN
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: blockcchevn
 
 - type: decal
+  parent: BasePathfindBlockChevron
   id: PathfindBlockCChevronW
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: blockcchevw
 
 - type: decal
+  parent: BasePathfindBlockChevron
   id: PathfindBlockCChevronE
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: blockccheve
 
 - type: decal
+  parent: BasePathfindBlockChevron
   id: PathfindBlockCChevronS
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: blockcchevs
 
 - type: decal
+  parent: BasePathfindBlockChevron
   id: PathfindBlockEChevronN
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: blockechevn
 
 - type: decal
+  parent: BasePathfindBlockChevron
   id: PathfindBlockEChevronW
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: blockechevw
 
 - type: decal
+  parent: BasePathfindBlockChevron
   id: PathfindBlockEChevronE
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: blockecheve
 
 - type: decal
+  parent: BasePathfindBlockChevron
   id: PathfindBlockEChevronS
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: blockechevs
 
 - type: decal
+  parent: BasePathfindBlockChevron
   id: PathfindBlockSWChevronN
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: blockswchevn
 
 - type: decal
+  parent: BasePathfindBlockChevron
   id: PathfindBlockSWChevronW
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: blockswchevw
 
 - type: decal
+  parent: BasePathfindBlockChevron
   id: PathfindBlockSWChevronE
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: blockswcheve
 
 - type: decal
+  parent: BasePathfindBlockChevron
   id: PathfindBlockSWChevronS
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: blockswchevs
 
 - type: decal
+  parent: BasePathfindBlockChevron
   id: PathfindBlockSChevronN
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: blockschevn
 
 - type: decal
+  parent: BasePathfindBlockChevron
   id: PathfindBlockSChevronW
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: blockschevw
 
 - type: decal
+  parent: BasePathfindBlockChevron
   id: PathfindBlockSChevronE
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: blockscheve
 
 - type: decal
+  parent: BasePathfindBlockChevron
   id: PathfindBlockSChevronS
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: blockschevs
 
 - type: decal
+  parent: BasePathfindBlockChevron
   id: PathfindBlockSEChevronN
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: blocksechevn
 
 - type: decal
+  parent: BasePathfindBlockChevron
   id: PathfindBlockSEChevronW
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: blocksechevw
 
 - type: decal
+  parent: BasePathfindBlockChevron
   id: PathfindBlockSEChevronE
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: blocksecheve
 
 - type: decal
+  parent: BasePathfindBlockChevron
   id: PathfindBlockSEChevronS
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
@@ -349,216 +446,252 @@
 # chevron fill pieces
 
 - type: decal
+  parent: BasePathfindFillChevron
   id: PathfindBlockNWChevronFillN
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: blocknwchevfilln
 
 - type: decal
+  parent: BasePathfindFillChevron
   id: PathfindBlockNWChevronFillW
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: blocknwchevfillw
 
 - type: decal
+  parent: BasePathfindFillChevron
   id: PathfindBlockNWChevronFillE
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: blocknwchevfille
 
 - type: decal
+  parent: BasePathfindFillChevron
   id: PathfindBlockNWChevronFillS
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: blocknwchevfills
 
 - type: decal
+  parent: BasePathfindFillChevron
   id: PathfindBlockNChevronFillN
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: blocknchevfilln
 
 - type: decal
+  parent: BasePathfindFillChevron
   id: PathfindBlockNChevronFillW
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: blocknchevfillw
 
 - type: decal
+  parent: BasePathfindFillChevron
   id: PathfindBlockNChevronFillE
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: blocknchevfille
 
 - type: decal
+  parent: BasePathfindFillChevron
   id: PathfindBlockNChevronFillS
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: blocknchevfills
 
 - type: decal
+  parent: BasePathfindFillChevron
   id: PathfindBlockNEChevronFillN
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: blocknechevfilln
 
 - type: decal
+  parent: BasePathfindFillChevron
   id: PathfindBlockNEChevronFillW
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: blocknechevfillw
 
 - type: decal
+  parent: BasePathfindFillChevron
   id: PathfindBlockNEChevronFillE
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: blocknechevfille
 
 - type: decal
+  parent: BasePathfindFillChevron
   id: PathfindBlockNEChevronFillS
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: blocknechevfills
 
 - type: decal
+  parent: BasePathfindFillChevron
   id: PathfindBlockWChevronFillN
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: blockwchevfilln
 
 - type: decal
+  parent: BasePathfindFillChevron
   id: PathfindBlockWChevronFillW
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: blockwchevfillw
 
 - type: decal
+  parent: BasePathfindFillChevron
   id: PathfindBlockWChevronFillE
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: blockwchevfille
 
 - type: decal
+  parent: BasePathfindFillChevron
   id: PathfindBlockWChevronFillS
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: blockwchevfills
 
 - type: decal
+  parent: BasePathfindFillChevron
   id: PathfindBlockCChevronFillN
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: blockcchevfilln
 
 - type: decal
+  parent: BasePathfindFillChevron
   id: PathfindBlockCChevronFillW
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: blockcchevfillw
 
 - type: decal
+  parent: BasePathfindFillChevron
   id: PathfindBlockCChevronFillE
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: blockcchevfille
 
 - type: decal
+  parent: BasePathfindFillChevron
   id: PathfindBlockCChevronFillS
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: blockcchevfills
 
 - type: decal
+  parent: BasePathfindFillChevron
   id: PathfindBlockEChevronFillN
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: blockechevfilln
 
 - type: decal
+  parent: BasePathfindFillChevron
   id: PathfindBlockEChevronFillW
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: blockechevfillw
 
 - type: decal
+  parent: BasePathfindFillChevron
   id: PathfindBlockEChevronFillE
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: blockechevfille
 
 - type: decal
+  parent: BasePathfindFillChevron
   id: PathfindBlockEChevronFillS
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: blockechevfills
 
 - type: decal
+  parent: BasePathfindFillChevron
   id: PathfindBlockSWChevronFillN
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: blockswchevfilln
 
 - type: decal
+  parent: BasePathfindFillChevron
   id: PathfindBlockSWChevronFillW
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: blockswchevfillw
 
 - type: decal
+  parent: BasePathfindFillChevron
   id: PathfindBlockSWChevronFillE
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: blockswchevfille
 
 - type: decal
+  parent: BasePathfindFillChevron
   id: PathfindBlockSWChevronFillS
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: blockswchevfills
 
 - type: decal
+  parent: BasePathfindFillChevron
   id: PathfindBlockSChevronFillN
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: blockschevfilln
 
 - type: decal
+  parent: BasePathfindFillChevron
   id: PathfindBlockSChevronFillW
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: blockschevfillw
 
 - type: decal
+  parent: BasePathfindFillChevron
   id: PathfindBlockSChevronFillE
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: blockschevfille
 
 - type: decal
+  parent: BasePathfindFillChevron
   id: PathfindBlockSChevronFillS
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: blockschevfills
 
 - type: decal
+  parent: BasePathfindFillChevron
   id: PathfindBlockSEChevronFillN
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: blocksechevfilln
 
 - type: decal
+  parent: BasePathfindFillChevron
   id: PathfindBlockSEChevronFillW
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: blocksechevfillw
 
 - type: decal
+  parent: BasePathfindFillChevron
   id: PathfindBlockSEChevronFillE
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: blocksechevfille
 
 - type: decal
+  parent: BasePathfindFillChevron
   id: PathfindBlockSEChevronFillS
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
@@ -567,108 +700,126 @@
 # symbol containers
 
 - type: decal
+  parent: BasePathfindSymbolContainer
   id: PathfindSymbolContainerNWH
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: symconnwh
 
 - type: decal
+  parent: BasePathfindSymbolContainer
   id: PathfindSymbolContainerNWV
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: symconnwv
 
 - type: decal
+  parent: BasePathfindSymbolContainer
   id: PathfindSymbolContainerNH
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: symconnh
 
 - type: decal
+  parent: BasePathfindSymbolContainer
   id: PathfindSymbolContainerNV
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: symconnv
 
 - type: decal
+  parent: BasePathfindSymbolContainer
   id: PathfindSymbolContainerNEH
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: symconneh
 
 - type: decal
+  parent: BasePathfindSymbolContainer
   id: PathfindSymbolContainerNEV
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: symconnev
 
 - type: decal
+  parent: BasePathfindSymbolContainer
   id: PathfindSymbolContainerWH
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: symconwh
 
 - type: decal
+  parent: BasePathfindSymbolContainer
   id: PathfindSymbolContainerWV
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: symconwv
 
 - type: decal
+  parent: BasePathfindSymbolContainer
   id: PathfindSymbolContainerCH
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: symconch
 
 - type: decal
+  parent: BasePathfindSymbolContainer
   id: PathfindSymbolContainerCV
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: symconcv
 
 - type: decal
+  parent: BasePathfindSymbolContainer
   id: PathfindSymbolContainerEH
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: symconeh
 
 - type: decal
+  parent: BasePathfindSymbolContainer
   id: PathfindSymbolContainerEV
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: symconev
 
 - type: decal
+  parent: BasePathfindSymbolContainer
   id: PathfindSymbolContainerSWH
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: symconswh
 
 - type: decal
+  parent: BasePathfindSymbolContainer
   id: PathfindSymbolContainerSWV
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: symconswv
 
 - type: decal
+  parent: BasePathfindSymbolContainer
   id: PathfindSymbolContainerSH
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: symconsh
 
 - type: decal
+  parent: BasePathfindSymbolContainer
   id: PathfindSymbolContainerSV
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: symconsv
 
 - type: decal
+  parent: BasePathfindSymbolContainer
   id: PathfindSymbolContainerSEH
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: symconseh
 
 - type: decal
+  parent: BasePathfindSymbolContainer
   id: PathfindSymbolContainerSEV
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
@@ -677,180 +828,210 @@
 # yield pieces
 
 - type: decal
+  parent: BasePathfindYield
   id: PathfindYieldLeftRT
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: lyieldrt
 
 - type: decal
+  parent: BasePathfindYield
   id: PathfindYieldLeftRC
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: lyieldrc
 
 - type: decal
+  parent: BasePathfindYield
   id: PathfindYieldLeftRB
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: lyieldrb
 
 - type: decal
+  parent: BasePathfindYield
   id: PathfindYieldTopUL
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: tyieldul
 
 - type: decal
+  parent: BasePathfindYield
   id: PathfindYieldTopUC
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: tyielduc
 
 - type: decal
+  parent: BasePathfindYield
   id: PathfindYieldTopUR
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: tyieldur
 
 - type: decal
+  parent: BasePathfindYield
   id: PathfindYieldCenterLT
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: cyieldlt
 
 - type: decal
+  parent: BasePathfindYield
   id: PathfindYieldCenterLC
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: cyieldlc
 
 - type: decal
+  parent: BasePathfindYield
   id: PathfindYieldCenterLB
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: cyieldlb
 
 - type: decal
+  parent: BasePathfindYield
   id: PathfindYieldCenterDL
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: cyielddl
 
 - type: decal
+  parent: BasePathfindYield
   id: PathfindYieldCenterDC
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: cyielddc
 
 - type: decal
+  parent: BasePathfindYield
   id: PathfindYieldCenterDR
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: cyielddr
 
 - type: decal
+  parent: BasePathfindYield
   id: PathfindYieldCenterRT
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: cyieldrt
 
 - type: decal
+  parent: BasePathfindYield
   id: PathfindYieldCenterRC
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: cyieldrc
 
 - type: decal
+  parent: BasePathfindYield
   id: PathfindYieldCenterRB
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: cyieldrb
 
 - type: decal
+  parent: BasePathfindYield
   id: PathfindYieldCenterUL
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: cyieldul
 
 - type: decal
+  parent: BasePathfindYield
   id: PathfindYieldCenterUC
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: cyielduc
 
 - type: decal
+  parent: BasePathfindYield
   id: PathfindYieldCenterUR
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: cyieldur
 
 - type: decal
+  parent: BasePathfindYield
   id: PathfindYieldCenterBT
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: cyieldbt
 
 - type: decal
+  parent: BasePathfindYield
   id: PathfindYieldCenterBCV
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: cyieldbcv
 
 - type: decal
+  parent: BasePathfindYield
   id: PathfindYieldCenterBB
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: cyieldbb
 
 - type: decal
+  parent: BasePathfindYield
   id: PathfindYieldCenterBL
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: cyieldbl
 
 - type: decal
+  parent: BasePathfindYield
   id: PathfindYieldCenterBCH
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: cyieldbch
 
 - type: decal
+  parent: BasePathfindYield
   id: PathfindYieldCenterBR
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: cyieldbr
 
 - type: decal
+  parent: BasePathfindYield
   id: PathfindYieldRightLT
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: ryieldlt
 
 - type: decal
+  parent: BasePathfindYield
   id: PathfindYieldRightLC
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: ryieldlc
 
 - type: decal
+  parent: BasePathfindYield
   id: PathfindYieldRightLB
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: ryieldlb
 
 - type: decal
+  parent: BasePathfindYield
   id: PathfindYieldBottomDC
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: byielddc
 
 - type: decal
+  parent: BasePathfindYield
   id: PathfindYieldBottomDL
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: byielddl
 
 - type: decal
+  parent: BasePathfindYield
   id: PathfindYieldBottomDR
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
@@ -859,222 +1040,259 @@
 # prefabs to save time
 
 - type: decal
+  parent: BasePathfindPrefab
   id: PathfindPrefabBendCenter
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: prefab_bendcenter
 
 - type: decal
+  parent: BasePathfindPrefab
   id: PathfindPrefabBendCenterChevD
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: prefab_bendcenterchevd
 
 - type: decal
+  parent: BasePathfindPrefab
   id: PathfindPrefabBendCenterChevU
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: prefab_bendcenterchevu
 
 - type: decal
+  parent: BasePathfindPrefab
   id: PathfindPrefabBendInner
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: prefab_bendinner
 
 - type: decal
+  parent: BasePathfindPrefab
   id: PathfindPrefabBendOuter
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: prefab_bendouter
 
 - type: decal
+  parent: BasePathfindPrefab
   id: PathfindPrefabBendOuterChevD
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: prefab_bendouterchevd
 
 - type: decal
+  parent: BasePathfindPrefab
   id: PathfindPrefabBendOuterChevU
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: prefab_bendouterchevu
 
 - type: decal
+  parent: BasePathfindPrefab
   id: PathfindPrefabHBottom
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: prefab_hbottom
 
 - type: decal
+  parent: BasePathfindPrefab
   id: PathfindPrefabHBottomChevL
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: prefab_hbottomchevl
 
 - type: decal
+  parent: BasePathfindPrefab
   id: PathfindPrefabHBottomChevLJunc
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: prefab_hbottomchevljunc
 
 - type: decal
+  parent: BasePathfindPrefab
   id: PathfindPrefabHBottomChevR
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: prefab_hbottomchevr
 
 - type: decal
+  parent: BasePathfindPrefab
   id: PathfindPrefabHBottomChevRJunc
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: prefab_hbottomchevrjunc
 
 - type: decal
+  parent: BasePathfindPrefab
   id: PathfindPrefabHCenter
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: prefab_hcenter
 
 - type: decal
+  parent: BasePathfindPrefab
   id: PathfindPrefabHCenterChevL
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: prefab_hcenterchevl
 
 - type: decal
+  parent: BasePathfindPrefab
   id: PathfindPrefabHCenterChevLJunc
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: prefab_hcenterchevljunc
 
 - type: decal
+  parent: BasePathfindPrefab
   id: PathfindPrefabHCenterChevR
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: prefab_hcenterchevr
 
 - type: decal
+  parent: BasePathfindPrefab
   id: PathfindPrefabHCenterChevRJunc
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: prefab_hcenterchevrjunc
 
 - type: decal
+  parent: BasePathfindPrefab
   id: PathfindPrefabHTop
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: prefab_htop
 
 - type: decal
+  parent: BasePathfindPrefab
   id: PathfindPrefabHTopChevL
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: prefab_htopchevl
 
 - type: decal
+  parent: BasePathfindPrefab
   id: PathfindPrefabHTopChevLJunc
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: prefab_htopchevljunc
 
 - type: decal
+  parent: BasePathfindPrefab
   id: PathfindPrefabHTopChevR
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: prefab_htopchevr
 
 - type: decal
+  parent: BasePathfindPrefab
   id: PathfindPrefabHTopChevRJunc
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: prefab_htopchevrjunc
 
 - type: decal
+  parent: BasePathfindPrefab
   id: PathfindPrefabVCenter
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: prefab_vcenter
 
 - type: decal
+  parent: BasePathfindPrefab
   id: PathfindPrefabVCenterChevD
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: prefab_vcenterchevd
 
 - type: decal
+  parent: BasePathfindPrefab
   id: PathfindPrefabVCenterChevDJunc
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: prefab_vcenterchevdjunc
 
 - type: decal
+  parent: BasePathfindPrefab
   id: PathfindPrefabVCenterChevU
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: prefab_vcenterchevu
 
 - type: decal
+  parent: BasePathfindPrefab
   id: PathfindPrefabVCenterChevUJunc
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: prefab_vcenterchevujunc
 
 - type: decal
+  parent: BasePathfindPrefab
   id: PathfindPrefabVLeft
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: prefab_vleft
 
 - type: decal
+  parent: BasePathfindPrefab
   id: PathfindPrefabVLeftChevD
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: prefab_vleftchevd
 
 - type: decal
+  parent: BasePathfindPrefab
   id: PathfindPrefabVLeftChevDJunc
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: prefab_vleftchevdjunc
 
 - type: decal
+  parent: BasePathfindPrefab
   id: PathfindPrefabVLeftChevU
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: prefab_vleftchevu
 
 - type: decal
+  parent: BasePathfindPrefab
   id: PathfindPrefabVLeftChevUJunc
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: prefab_vleftchevujunc
 
 - type: decal
+  parent: BasePathfindPrefab
   id: PathfindPrefabVRight
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: prefab_vright
 
 - type: decal
+  parent: BasePathfindPrefab
   id: PathfindPrefabVRightChevD
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: prefab_vrightchevd
 
 - type: decal
+  parent: BasePathfindPrefab
   id: PathfindPrefabVRightChevDJunc
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: prefab_vrightchevdjunc
 
 - type: decal
+  parent: BasePathfindPrefab
   id: PathfindPrefabVRightChevU
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi
     state: prefab_vrightchevu
 
 - type: decal
+  parent: BasePathfindPrefab
   id: PathfindPrefabVRightChevUJunc
   sprite:
     sprite: _MACRO/Decals/pathfind.rsi


### PR DESCRIPTION
## About the PR
this PR just adds parent prototypes to all the decals added in #9.

## Why / Balance
did you know that decals are inheriting prototypes.
on den rebase i wanted to add all of these markings to the spray painter and maybe the crayons, but i realized it would require editing hundreds of prototypes one way or another. this makes that cleaner.

## Technical details
i made an abstract prototype and then added the `parent` field to a fuck ton of decals.

## Test plan
two beautiful baby girls named "Build Test Debug" and "YAML Linter"

## Requirements
- [x] I have read and am following the Macrocosm [Pull Request Conventions](https://docs.macrocosm.cool/docs/Conventions/pull-requests/).
- [ ] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
not really?

## Changelog
not player-facing.